### PR TITLE
fix: keep BBDown login state on both platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to MAD Toolbox are documented here.
 
+## 0.5.7 - 2026-08-01
+
+- Fixed bundled BBDown login state on macOS and Windows by running it from a
+  writable app-data directory, keeping `BBDown.data` beside the executable as
+  expected by the original CLI, and allowing a new QR login to replace the
+  previous session.
+- Added live login-state feedback so a failed BBDown account check is not
+  mistaken for a successful local-cookie load.
+
 ## 0.5.6 - 2026-08-01
 
 - Updated the pinned Windows Full FFmpeg asset and executable checksums after

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -1,6 +1,6 @@
 # Windows x64 build
 
-MAD Toolbox 0.5.4 targets Windows 10 22H2 and Windows 11 on Intel/AMD x64
+MAD Toolbox 0.5.7 targets Windows 10 22H2 and Windows 11 on Intel/AMD x64
 processors (`x86_64-pc-windows-msvc`). ARM64 and 32-bit x86 installers are not
 currently produced.
 
@@ -42,8 +42,14 @@ The output is a per-user bilingual NSIS installer.
 
 ## CLI state and diagnostics
 
-BBDown creates and reads its own `BBDown.data` beside the executable. MAD
-Toolbox does not parse, move, encrypt or inject this native state and does not
+The bundled BBDown is copied to the per-user application data directory at
+first use. Its native `BBDown.data` is kept beside that runtime copy, so login
+and download always use the same file on macOS and Windows. A legacy
+`BBDown.data` beside an older bundled executable is migrated once when the new
+location is empty. Running QR login again lets BBDown overwrite that file with
+the newly returned session, exactly as its original CLI does.
+
+MAD Toolbox does not parse, encrypt or inject this native state and does not
 use Credential Manager. Templates are ordinary WebView application data.
 Exported task logs preserve original CLI output and may therefore contain
 cookies, passwords, tokens, proxy credentials, URLs and local paths.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mad-toolbox",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mad-toolbox",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mad-toolbox",
   "private": true,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "mad-toolbox"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mad-toolbox"
-version = "0.5.6"
+version = "0.5.7"
 description = "A GUI toolbox for BBDown, yt-dlp, FFmpeg and MediaInfo"
 authors = ["MAD Toolbox Contributors"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -731,6 +731,106 @@ fn bbdown_working_dir(app: &AppHandle) -> Result<PathBuf, String> {
     Ok(path)
 }
 
+/// BBDown 1.6.3 stores BBDown.data beside its own executable (Program.APP_DIR),
+/// not beside the download output directory.  A bundled executable inside an
+/// installed app is not a reliable place for a user-writable session file,
+/// especially on Windows and signed macOS app bundles.  Run a private copy from
+/// the app-data directory so login and download always share the same native
+/// BBDown files on both platforms.
+fn prepare_bbdown_runtime(app: &AppHandle, bundled: &Path) -> Result<PathBuf, String> {
+    let runtime_dir = bbdown_working_dir(app)?;
+    let runtime_binary = runtime_dir.join(executable_filename("BBDown"));
+
+    // Preserve files created by the original CLI, including an existing login,
+    // config, and archive file next to a previously bundled executable.
+    let mut legacy_dirs = Vec::new();
+    if let Some(parent) = bundled.parent() {
+        legacy_dirs.push(parent.to_path_buf());
+    }
+    if let Ok(resources) = app.path().resource_dir() {
+        legacy_dirs.push(resources.clone());
+        legacy_dirs.push(resources.join("binaries"));
+    }
+    if let Ok(current) = env::current_exe() {
+        if let Some(parent) = current.parent() {
+            legacy_dirs.push(parent.to_path_buf());
+        }
+    }
+    legacy_dirs.sort();
+    legacy_dirs.dedup();
+    for filename in [
+        "BBDown.data",
+        "BBDownTV.data",
+        "BBDownApp.data",
+        "BBDown.config",
+        "BBDown.archives",
+    ] {
+        let target = runtime_dir.join(filename);
+        if target.is_file() {
+            continue;
+        }
+        for directory in &legacy_dirs {
+            let source = directory.join(filename);
+            if source.is_file() && !same_binary(&source, &target) {
+                let _ = std::fs::copy(&source, &target);
+                if target.is_file() {
+                    break;
+                }
+            }
+        }
+    }
+
+    // The bundled BBDown is a self-contained executable.  Copy it once (or
+    // refresh it when the packaged size changes) into the same directory as
+    // BBDown.data.  If Windows has an older runtime process open, retain the
+    // already working copy instead of breaking a new task.
+    let source_size = std::fs::metadata(bundled)
+        .map_err(|error| format!("无法读取 BBDown：{error}"))?
+        .len();
+    let needs_copy = !runtime_binary.is_file()
+        || std::fs::metadata(&runtime_binary)
+            .map(|metadata| metadata.len() != source_size)
+            .unwrap_or(true);
+    if needs_copy {
+        let temporary = runtime_dir.join(format!(".BBDown-{}.tmp", Uuid::new_v4()));
+        let copy_result = (|| {
+            std::fs::copy(bundled, &temporary)
+                .map_err(|error| format!("无法准备 BBDown：{error}"))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mode = std::fs::metadata(bundled)
+                    .map_err(|error| format!("无法读取 BBDown 权限：{error}"))?
+                    .permissions()
+                    .mode();
+                std::fs::set_permissions(&temporary, std::fs::Permissions::from_mode(mode | 0o111))
+                    .map_err(|error| format!("无法设置 BBDown 权限：{error}"))?;
+            }
+            if runtime_binary.is_file() {
+                std::fs::remove_file(&runtime_binary)
+                    .map_err(|error| format!("无法更新 BBDown：{error}"))?;
+            }
+            std::fs::rename(&temporary, &runtime_binary)
+                .map_err(|error| format!("无法保存 BBDown：{error}"))?;
+            Ok::<(), String>(())
+        })();
+        if copy_result.is_err() {
+            let _ = std::fs::remove_file(&temporary);
+            if !runtime_binary.is_file() {
+                return Err(copy_result
+                    .err()
+                    .unwrap_or_else(|| "无法准备 BBDown 运行文件".into()));
+            }
+        }
+    }
+
+    if runtime_binary.is_file() {
+        Ok(runtime_binary)
+    } else {
+        Err("无法准备 BBDown 运行文件".into())
+    }
+}
+
 fn strip_ansi_codes(line: &str) -> String {
     let mut output = String::with_capacity(line.len());
     let mut characters = line.chars().peekable();
@@ -989,6 +1089,8 @@ async fn stream_output<R>(
         {
             continue;
         }
+        // Preserve the original CLI output in the task center; credential
+        // redaction remains available for the diagnostic ZIP export.
         emit_log(&app, &job_id, &tool, stream, strip_ansi_codes(&line));
     }
 }
@@ -1570,8 +1672,13 @@ async fn run_tool(
     state: State<'_, AppState>,
     mut request: RunRequest,
 ) -> Result<RunResult, String> {
-    let (executable, _) = resolve_tool(&app, &request.tool)
+    let (resolved_executable, bundled) = resolve_tool(&app, &request.tool)
         .ok_or_else(|| format!("未找到 {}，请先安装依赖", request.tool.label()))?;
+    let executable = if matches!(request.tool, ToolName::Bbdown) && bundled {
+        prepare_bbdown_runtime(&app, &resolved_executable)?
+    } else {
+        resolved_executable
+    };
     let is_login = matches!(request.tool, ToolName::Bbdown)
         && request.args.first().map(String::as_str) == Some("login");
     if matches!(request.tool, ToolName::YtDlp)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MAD Toolbox",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "identifier": "org.madproducer.toolbox",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,9 +64,7 @@ export default function App() {
   const backend = useBackend();
   const distributionMode =
     backend.dependencies.some((item) => item.required) &&
-    backend.dependencies.every(
-      (item) => !item.required || item.bundledAvailable
-    )
+    backend.dependencies.every((item) => !item.required || item.bundledAvailable)
       ? "Full"
       : "Lite";
 
@@ -248,10 +246,14 @@ export default function App() {
       <aside className="sidebar">
         <div className="window-drag" data-tauri-drag-region />
         <div className="brand">
-          <span className="brand-icon"><img src={appIcon} alt="" /></span>
+          <span className="brand-icon">
+            <img src={appIcon} alt="" />
+          </span>
           <span>
             <strong>MAD Toolbox</strong>
-            <small>v{packageInfo.version} · {distributionMode}</small>
+            <small>
+              v{packageInfo.version} · {distributionMode}
+            </small>
           </span>
         </div>
         <nav>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,6 +178,7 @@ export default function App() {
       return (
         <BilibiliPage
           bbdownAvailable={backend.dependencyMap.get("bbdown")?.available ?? false}
+          bbdownAuthStatus={backend.bbdownAuthStatus}
           loginQr={backend.loginQr}
           onRun={run}
         />

--- a/src/hooks/useBackend.ts
+++ b/src/hooks/useBackend.ts
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type {
   AppSettings,
+  BbdownAuthStatus,
   DependencyStatus,
   JobLog,
   JobState,
@@ -19,6 +20,7 @@ export function useBackend() {
   const [loadingDependencies, setLoadingDependencies] = useState(true);
   const [ffmpegEncoders, setFfmpegEncoders] = useState<string[]>([]);
   const [loginQr, setLoginQr] = useState<LoginQr | null>(null);
+  const [bbdownAuthStatus, setBbdownAuthStatus] = useState<BbdownAuthStatus>("unknown");
   const [settings, setSettings] = useState<AppSettings>({
     defaultOutputDirectory: null,
     dependencyPreference: "bundled"
@@ -54,6 +56,22 @@ export function useBackend() {
     void refreshSettings();
     const unlistenLog = listen<JobLog>("job-log", ({ payload }) => {
       setLogs((current) => [...current.slice(-4999), payload]);
+      if (payload.tool === "bbdown") {
+        const line = payload.line.replace(/\s+/g, "").toLowerCase();
+        if (line.includes("登录成功")) {
+          setBbdownAuthStatus("authenticated");
+        } else if (
+          line.includes("尚未登录") ||
+          line.includes("未登录") ||
+          line.includes("未获取到b站账号") ||
+          line.includes("解析可能受到限制") ||
+          line.includes("cookie无效") ||
+          line.includes("cookie失效") ||
+          line.includes("cookie过期")
+        ) {
+          setBbdownAuthStatus("unauthenticated");
+        }
+      }
     });
     const unlistenQr = listen<LoginQr>("bbdown-login-qr", ({ payload }) => {
       setLoginQr(payload);
@@ -75,6 +93,9 @@ export function useBackend() {
   }, [refreshDependencies, refreshSettings]);
 
   const runTool = useCallback(async (request: RunRequest) => {
+    if (request.tool === "bbdown" && request.args[0] === "login") {
+      setBbdownAuthStatus("unknown");
+    }
     return invoke<RunResult>("run_tool", { request });
   }, []);
 
@@ -95,6 +116,7 @@ export function useBackend() {
     logs,
     jobs,
     loginQr,
+    bbdownAuthStatus,
     settings,
     saveSettings,
     refreshDependencies,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,12 +1,5 @@
 export type ToolName =
-  | "bbdown"
-  | "yt-dlp"
-  | "musicdl"
-  | "ffmpeg"
-  | "ffprobe"
-  | "mediainfo"
-  | "deno"
-  | "python";
+  "bbdown" | "yt-dlp" | "musicdl" | "ffmpeg" | "ffprobe" | "mediainfo" | "deno" | "python";
 
 export interface DependencyStatus {
   tool: ToolName;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,8 @@ export interface LoginQr {
   dataUrl: string;
 }
 
+export type BbdownAuthStatus = "unknown" | "authenticated" | "unauthenticated";
+
 export interface MediaInspection {
   path: string;
   summary: string;

--- a/src/pages/BilibiliPage.tsx
+++ b/src/pages/BilibiliPage.tsx
@@ -153,7 +153,9 @@ export function BilibiliPage({
         <ShieldCheck size={17} />
         <div>
           <strong>下载规格取决于当前 B站账号权限</strong>
-          <p>“最高规格”指该账号当前可访问的最高规格。大会员画质、HDR、杜比视界、高码率及会员视频需要账号具备对应会员、内容与地区权限。</p>
+          <p>
+            “最高规格”指该账号当前可访问的最高规格。大会员画质、HDR、杜比视界、高码率及会员视频需要账号具备对应会员、内容与地区权限。
+          </p>
         </div>
       </section>
 
@@ -274,43 +276,83 @@ export function BilibiliPage({
                 />
               </Field>
               <Field label="混流音频语言" hint="ISO 639-2 代码，例如 chi、jpn。">
-                <TextInput value={options.language} onChange={(e) => update("language", e.target.value)} />
+                <TextInput
+                  value={options.language}
+                  onChange={(e) => update("language", e.target.value)}
+                />
               </Field>
               <Field label="User-Agent">
-                <TextInput value={options.userAgent} onChange={(e) => update("userAgent", e.target.value)} />
+                <TextInput
+                  value={options.userAgent}
+                  onChange={(e) => update("userAgent", e.target.value)}
+                />
               </Field>
               <Field label="Cookie" hint="可选，用于手动指定 BBDown 登录 Cookie。">
-                <TextInput type="password" value={options.cookie} onChange={(e) => update("cookie", e.target.value)} />
+                <TextInput
+                  type="password"
+                  value={options.cookie}
+                  onChange={(e) => update("cookie", e.target.value)}
+                />
               </Field>
               <Field label="Access Token" hint="TV、APP 或 BiliPlus 接口所需。">
-                <TextInput type="password" value={options.accessToken} onChange={(e) => update("accessToken", e.target.value)} />
+                <TextInput
+                  type="password"
+                  value={options.accessToken}
+                  onChange={(e) => update("accessToken", e.target.value)}
+                />
               </Field>
               <Field label="合集分 P 间隔（秒）">
-                <TextInput type="number" min={0} value={options.delayPerPage} onChange={(e) => update("delayPerPage", e.target.value)} />
+                <TextInput
+                  type="number"
+                  min={0}
+                  value={options.delayPerPage}
+                  onChange={(e) => update("delayPerPage", e.target.value)}
+                />
               </Field>
               <Field label="UPOS 服务器">
-                <TextInput value={options.uposHost} onChange={(e) => update("uposHost", e.target.value)} />
+                <TextInput
+                  value={options.uposHost}
+                  onChange={(e) => update("uposHost", e.target.value)}
+                />
               </Field>
               <Field label="aria2c 路径">
-                <TextInput value={options.aria2cPath} onChange={(e) => update("aria2cPath", e.target.value)} />
+                <TextInput
+                  value={options.aria2cPath}
+                  onChange={(e) => update("aria2cPath", e.target.value)}
+                />
               </Field>
               <Field label="aria2c 附加参数">
-                <TextInput value={options.aria2cArgs} onChange={(e) => update("aria2cArgs", e.target.value)} />
+                <TextInput
+                  value={options.aria2cArgs}
+                  onChange={(e) => update("aria2cArgs", e.target.value)}
+                />
               </Field>
               <Field label="MP4Box 路径">
-                <TextInput value={options.mp4boxPath} onChange={(e) => update("mp4boxPath", e.target.value)} />
+                <TextInput
+                  value={options.mp4boxPath}
+                  onChange={(e) => update("mp4boxPath", e.target.value)}
+                />
               </Field>
               <Field label="BBDown 配置文件">
-                <TextInput value={options.configFile} onChange={(e) => update("configFile", e.target.value)} />
+                <TextInput
+                  value={options.configFile}
+                  onChange={(e) => update("configFile", e.target.value)}
+                />
               </Field>
               <Field label="BiliPlus Host">
                 <TextInput value={options.host} onChange={(e) => update("host", e.target.value)} />
               </Field>
               <Field label="BiliPlus EP Host">
-                <TextInput value={options.epHost} onChange={(e) => update("epHost", e.target.value)} />
+                <TextInput
+                  value={options.epHost}
+                  onChange={(e) => update("epHost", e.target.value)}
+                />
               </Field>
               <Field label="BiliPlus 地区">
-                <SelectInput value={options.area} onChange={(e) => update("area", e.target.value as BilibiliOptions["area"])}>
+                <SelectInput
+                  value={options.area}
+                  onChange={(e) => update("area", e.target.value as BilibiliOptions["area"])}
+                >
                   <option value="">不指定</option>
                   <option value="hk">香港（hk）</option>
                   <option value="tw">台湾（tw）</option>
@@ -319,25 +361,99 @@ export function BilibiliPage({
               </Field>
             </div>
             <div className="toggle-grid">
-              <Toggle checked={options.useMp4box} onChange={(v) => update("useMp4box", v)} label="使用 MP4Box 混流" />
-              <Toggle checked={options.useAria2c} onChange={(v) => update("useAria2c", v)} label="使用 aria2c 下载" />
-              <Toggle checked={options.showAll} onChange={(v) => update("showAll", v)} label="展示全部分 P" />
-              <Toggle checked={options.hideStreams} onChange={(v) => update("hideStreams", v)} label="隐藏可用音视频流" />
-              <Toggle checked={options.skipMux} onChange={(v) => update("skipMux", v)} label="跳过混流" />
-              <Toggle checked={options.skipSubtitle} onChange={(v) => update("skipSubtitle", v)} label="跳过字幕" />
-              <Toggle checked={options.skipCover} onChange={(v) => update("skipCover", v)} label="跳过封面" />
-              <Toggle checked={options.skipAi} onChange={(v) => update("skipAi", v)} label="跳过 AI 字幕" />
-              <Toggle checked={options.multiThread} onChange={(v) => update("multiThread", v)} label="显式启用多线程" hint="BBDown 默认已开启。" />
-              <Toggle checked={options.forceHttp} onChange={(v) => update("forceHttp", v)} label="强制使用 HTTP" hint="BBDown 默认已开启。" />
-              <Toggle checked={options.downloadDanmaku} onChange={(v) => update("downloadDanmaku", v)} label="随视频下载弹幕" />
-              <Toggle checked={options.videoAscending} onChange={(v) => update("videoAscending", v)} label="视频最小体积优先" />
-              <Toggle checked={options.audioAscending} onChange={(v) => update("audioAscending", v)} label="音频最小体积优先" />
-              <Toggle checked={options.allowPcdn} onChange={(v) => update("allowPcdn", v)} label="允许 PCDN" />
-              <Toggle checked={options.forceReplaceHost} onChange={(v) => update("forceReplaceHost", v)} label="强制替换下载 Host" hint="BBDown 默认已开启。" />
-              <Toggle checked={options.saveArchive} onChange={(v) => update("saveArchive", v)} label="记录下载历史" />
-              <Toggle checked={options.debug} onChange={(v) => update("debug", v)} label="调试日志" />
+              <Toggle
+                checked={options.useMp4box}
+                onChange={(v) => update("useMp4box", v)}
+                label="使用 MP4Box 混流"
+              />
+              <Toggle
+                checked={options.useAria2c}
+                onChange={(v) => update("useAria2c", v)}
+                label="使用 aria2c 下载"
+              />
+              <Toggle
+                checked={options.showAll}
+                onChange={(v) => update("showAll", v)}
+                label="展示全部分 P"
+              />
+              <Toggle
+                checked={options.hideStreams}
+                onChange={(v) => update("hideStreams", v)}
+                label="隐藏可用音视频流"
+              />
+              <Toggle
+                checked={options.skipMux}
+                onChange={(v) => update("skipMux", v)}
+                label="跳过混流"
+              />
+              <Toggle
+                checked={options.skipSubtitle}
+                onChange={(v) => update("skipSubtitle", v)}
+                label="跳过字幕"
+              />
+              <Toggle
+                checked={options.skipCover}
+                onChange={(v) => update("skipCover", v)}
+                label="跳过封面"
+              />
+              <Toggle
+                checked={options.skipAi}
+                onChange={(v) => update("skipAi", v)}
+                label="跳过 AI 字幕"
+              />
+              <Toggle
+                checked={options.multiThread}
+                onChange={(v) => update("multiThread", v)}
+                label="显式启用多线程"
+                hint="BBDown 默认已开启。"
+              />
+              <Toggle
+                checked={options.forceHttp}
+                onChange={(v) => update("forceHttp", v)}
+                label="强制使用 HTTP"
+                hint="BBDown 默认已开启。"
+              />
+              <Toggle
+                checked={options.downloadDanmaku}
+                onChange={(v) => update("downloadDanmaku", v)}
+                label="随视频下载弹幕"
+              />
+              <Toggle
+                checked={options.videoAscending}
+                onChange={(v) => update("videoAscending", v)}
+                label="视频最小体积优先"
+              />
+              <Toggle
+                checked={options.audioAscending}
+                onChange={(v) => update("audioAscending", v)}
+                label="音频最小体积优先"
+              />
+              <Toggle
+                checked={options.allowPcdn}
+                onChange={(v) => update("allowPcdn", v)}
+                label="允许 PCDN"
+              />
+              <Toggle
+                checked={options.forceReplaceHost}
+                onChange={(v) => update("forceReplaceHost", v)}
+                label="强制替换下载 Host"
+                hint="BBDown 默认已开启。"
+              />
+              <Toggle
+                checked={options.saveArchive}
+                onChange={(v) => update("saveArchive", v)}
+                label="记录下载历史"
+              />
+              <Toggle
+                checked={options.debug}
+                onChange={(v) => update("debug", v)}
+                label="调试日志"
+              />
             </div>
-            <Field label="其他参数（每行一个）" hint="临时兼容尚未列出的 BBDown 参数；不会经过 Shell 执行。">
+            <Field
+              label="其他参数（每行一个）"
+              hint="临时兼容尚未列出的 BBDown 参数；不会经过 Shell 执行。"
+            >
               <TextArea
                 rows={4}
                 value={options.extraArgs}

--- a/src/pages/BilibiliPage.tsx
+++ b/src/pages/BilibiliPage.tsx
@@ -1,7 +1,7 @@
 import { CircleHelp, LogIn, QrCode, ShieldCheck } from "lucide-react";
 import { useMemo, useState } from "react";
 import { buildBilibiliArgs, commandPreview, type BilibiliOptions } from "../lib/commands";
-import type { LoginQr, RunRequest, RunResult } from "../lib/types";
+import type { BbdownAuthStatus, LoginQr, RunRequest, RunResult } from "../lib/types";
 import { CommandBar } from "../components/CommandBar";
 import { Field, SelectInput, TextArea, TextInput, Toggle } from "../components/Field";
 import { DirectoryInput } from "../components/DirectoryInput";
@@ -10,6 +10,7 @@ import { defaultOutputPlaceholder } from "../lib/platform";
 
 interface BilibiliPageProps {
   bbdownAvailable: boolean;
+  bbdownAuthStatus: BbdownAuthStatus;
   loginQr: LoginQr | null;
   onRun: (request: RunRequest) => Promise<RunResult>;
 }
@@ -59,6 +60,7 @@ const initialOptions: BilibiliOptions = {
 
 export function BilibiliPage({
   bbdownAvailable,
+  bbdownAuthStatus,
   loginQr,
   onRun
 }: BilibiliPageProps) {
@@ -80,6 +82,24 @@ export function BilibiliPage({
       tool: "bbdown",
       args: ["login"]
     });
+
+  const authCopy = {
+    unknown: {
+      title: "登录状态待检测",
+      hint: "点击扫码登录，BBDown 会按原生方式保存并读取登录状态。",
+      button: "扫码登录"
+    },
+    authenticated: {
+      title: "已检测到哔哩哔哩登录",
+      hint: "BBDown 已取得账号权限，最终画质仍取决于账号和视频本身。",
+      button: "重新登录"
+    },
+    unauthenticated: {
+      title: "未检测到有效登录",
+      hint: "BBDown 报告账号未登录，请重新扫码并在手机上确认。",
+      button: "重新扫码登录"
+    }
+  }[bbdownAuthStatus];
 
   return (
     <div className="page">
@@ -110,13 +130,13 @@ export function BilibiliPage({
         </section>
       )}
 
-      <section className="auth-card">
+      <section className={`auth-card ${bbdownAuthStatus}`}>
         <div className="auth-icon">
           <QrCode size={24} />
         </div>
         <div className="auth-copy">
-          <strong>扫码登录哔哩哔哩</strong>
-          <span>使用哔哩哔哩手机客户端扫码，登录后可获取账号可用的下载规格。</span>
+          <strong>{authCopy.title}</strong>
+          <span>{authCopy.hint}</span>
         </div>
         <button
           className="primary-button"
@@ -125,7 +145,7 @@ export function BilibiliPage({
           disabled={!bbdownAvailable}
         >
           <LogIn size={15} />
-          扫码登录
+          {authCopy.button}
         </button>
       </section>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,14 @@
 :root {
   font-family:
-    Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "SF Pro Display",
-    "PingFang SC", "Helvetica Neue", Arial, sans-serif;
+    Inter,
+    ui-sans-serif,
+    -apple-system,
+    BlinkMacSystemFont,
+    "SF Pro Display",
+    "PingFang SC",
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
   color: #22252a;
   background: #eef0f3;
   font-synthesis: none;
@@ -1201,7 +1208,10 @@ button:disabled {
   margin: 0;
   overflow: auto;
   color: #444a53;
-  font: 9px/1.55 "SFMono-Regular", Consolas, monospace;
+  font:
+    9px/1.55 "SFMono-Regular",
+    Consolas,
+    monospace;
   white-space: pre-wrap;
 }
 
@@ -1412,7 +1422,10 @@ button:disabled {
   border: 1px solid #ebe8f1;
   border-radius: 7px;
   background: #f7f6fa;
-  font: 9px/1.4 "SFMono-Regular", Consolas, monospace;
+  font:
+    9px/1.4 "SFMono-Regular",
+    Consolas,
+    monospace;
   white-space: nowrap;
 }
 
@@ -1502,7 +1515,10 @@ button:disabled {
 .pip-mirror-grid article > code,
 .pip-reset-row code {
   color: #565079;
-  font: 8px/1.45 "SFMono-Regular", Consolas, monospace;
+  font:
+    8px/1.45 "SFMono-Regular",
+    Consolas,
+    monospace;
   overflow-wrap: anywhere;
   white-space: normal;
   word-break: break-word;

--- a/src/styles.css
+++ b/src/styles.css
@@ -598,6 +598,15 @@ button:disabled {
   background: #f5fbf8;
 }
 
+.auth-card.unauthenticated {
+  border-color: #e8d4dc;
+  background: #fff8fa;
+}
+
+.auth-card.unauthenticated .auth-icon {
+  color: #d65380;
+}
+
 .login-qr-card {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What changed

- Run the bundled BBDown executable from a writable per-user app-data directory on macOS and Windows.
- Migrate existing native BBDown data/config files and keep login/download on the same `Program.APP_DIR`.
- Allow a new QR login to overwrite the previous `BBDown.data`.
- Show the actual BBDown account-check result in the GUI instead of treating “loaded local cookie” as a successful login.
- Bump the app to 0.5.7.

## Root cause

BBDown 1.6.3 reads and writes `BBDown.data` beside its executable. The GUI launched the bundled binary from the app bundle/resource location while using a different working directory for tasks. That made the generated session file unreliable across installed macOS and Windows builds. The BBDown log also explicitly reported that the account was not logged in, which explains the 480p result.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `npm run check`
- `npm run build`
- Windows cross-check is delegated to the Windows CI runner; local macOS cross-compilation lacks `llvm-rc`.