### PR TITLE
fix: use bundled BBDown native login state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,11 @@ All notable changes to MAD Toolbox are documented here.
 
 ## 0.5.8 - 2026-08-01
 
-- Fixed BBDown login synchronization with standalone CLI installations on
-  macOS and Windows. When a user CLI with a native `BBDown.data` is found,
-  the GUI now invokes that exact executable and shares its session file.
-- Added discovery of common per-user tool directories, including
-  `Documents/apps/ffmpeg`, so GUI launches from Finder use the same `bbdown`
-  command that works in a terminal.
-- Added regression coverage for distinguishing a complete native session from
-  an incomplete QR-login ticket file.
+- Fixed bundled BBDown login state on macOS and Windows when an older GUI left
+  a temporary QR ticket in `BBDown.data`. The bundled runtime now keeps one
+  native BBDown state directory and lets BBDown recreate that file normally.
+- Added a small login-state indicator without parsing or storing credentials in
+  the GUI.
 
 ## 0.5.7 - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to MAD Toolbox are documented here.
 
+## 0.5.8 - 2026-08-01
+
+- Fixed BBDown login synchronization with standalone CLI installations on
+  macOS and Windows. When a user CLI with a native `BBDown.data` is found,
+  the GUI now invokes that exact executable and shares its session file.
+- Added discovery of common per-user tool directories, including
+  `Documents/apps/ffmpeg`, so GUI launches from Finder use the same `bbdown`
+  command that works in a terminal.
+- Added regression coverage for distinguishing a complete native session from
+  an incomplete QR-login ticket file.
+
 ## 0.5.7 - 2026-08-01
 
 - Fixed bundled BBDown login state on macOS and Windows by running it from a

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -1,6 +1,6 @@
 # Windows x64 build
 
-MAD Toolbox 0.5.7 targets Windows 10 22H2 and Windows 11 on Intel/AMD x64
+MAD Toolbox 0.5.8 targets Windows 10 22H2 and Windows 11 on Intel/AMD x64
 processors (`x86_64-pc-windows-msvc`). ARM64 and 32-bit x86 installers are not
 currently produced.
 
@@ -42,12 +42,15 @@ The output is a per-user bilingual NSIS installer.
 
 ## CLI state and diagnostics
 
-The bundled BBDown is copied to the per-user application data directory at
-first use. Its native `BBDown.data` is kept beside that runtime copy, so login
-and download always use the same file on macOS and Windows. A legacy
-`BBDown.data` beside an older bundled executable is migrated once when the new
-location is empty. Running QR login again lets BBDown overwrite that file with
-the newly returned session, exactly as its original CLI does.
+If a standalone `BBDown` is found in the user's normal tool directories and it
+already has a native login file, MAD Toolbox invokes that exact executable.
+This means `BBDown login` followed by `BBDown <url>` in a terminal and the GUI
+share the same `BBDown.data` on macOS and Windows. Otherwise the bundled
+BBDown is copied to the per-user application data directory at first use, with
+its native `BBDown.data` kept beside that runtime copy. A legacy file beside
+an older bundled executable is migrated once when the new location is empty.
+Running QR login again lets BBDown overwrite the active file with the newly
+returned session, exactly as its original CLI does.
 
 MAD Toolbox does not parse, encrypt or inject this native state and does not
 use Credential Manager. Templates are ordinary WebView application data.

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -42,15 +42,13 @@ The output is a per-user bilingual NSIS installer.
 
 ## CLI state and diagnostics
 
-If a standalone `BBDown` is found in the user's normal tool directories and it
-already has a native login file, MAD Toolbox invokes that exact executable.
-This means `BBDown login` followed by `BBDown <url>` in a terminal and the GUI
-share the same `BBDown.data` on macOS and Windows. Otherwise the bundled
-BBDown is copied to the per-user application data directory at first use, with
-its native `BBDown.data` kept beside that runtime copy. A legacy file beside
-an older bundled executable is migrated once when the new location is empty.
-Running QR login again lets BBDown overwrite the active file with the newly
-returned session, exactly as its original CLI does.
+The bundled BBDown is copied to the per-user application data directory at
+first use, with its native `BBDown.data` kept beside that runtime copy. Login
+and later downloads always run this same bundled executable, so BBDown reads
+and writes its own file exactly as in the original CLI. An old temporary QR
+ticket is ignored once and a valid native file beside an older bundled
+executable can be migrated. The GUI does not parse, encrypt, or inject the
+credentials.
 
 MAD Toolbox does not parse, encrypt or inject this native state and does not
 use Credential Manager. Templates are ordinary WebView application data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mad-toolbox",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mad-toolbox",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mad-toolbox",
   "private": true,
-  "version": "0.5.7",
+  "version": "0.5.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "mad-toolbox"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mad-toolbox"
-version = "0.5.7"
+version = "0.5.8"
 description = "A GUI toolbox for BBDown, yt-dlp, FFmpeg and MediaInfo"
 authors = ["MAD Toolbox Contributors"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -305,9 +305,6 @@ fn command_path() -> OsString {
         }
         if let Some(profile) = env::var_os("USERPROFILE") {
             let profile = PathBuf::from(profile);
-            paths.push(profile.join("Documents").join("apps").join("ffmpeg"));
-            paths.push(profile.join("Documents").join("apps"));
-            paths.push(profile.join("bin"));
             paths.push(profile.join(".local").join("bin"));
             paths.push(profile.join("scoop").join("shims"));
         }
@@ -339,11 +336,7 @@ fn command_path() -> OsString {
     }
     #[cfg(not(target_os = "windows"))]
     if let Some(home) = env::var_os("HOME") {
-        let home = PathBuf::from(home);
-        paths.push(home.join("Documents").join("apps").join("ffmpeg"));
-        paths.push(home.join("Documents").join("apps"));
-        paths.push(home.join("bin"));
-        paths.push(home.join(".local").join("bin"));
+        paths.push(PathBuf::from(home).join(".local").join("bin"));
     }
     if let Ok(current) = env::current_exe() {
         if let Some(parent) = current.parent() {
@@ -362,33 +355,21 @@ fn executable_filename(name: &str) -> String {
     }
 }
 
-fn executable_filenames(name: &str) -> Vec<String> {
-    let primary = executable_filename(name);
-    if name.eq_ignore_ascii_case("bbdown") {
-        let alternate = executable_filename("bbdown");
-        if alternate != primary {
-            return vec![primary, alternate];
-        }
-    }
-    vec![primary]
-}
-
 fn find_system_binary(name: &str) -> Option<PathBuf> {
+    let filename = executable_filename(name);
     for directory in env::split_paths(&command_path()) {
-        for filename in executable_filenames(name) {
-            let candidate = directory.join(filename);
-            #[cfg(target_os = "windows")]
-            if matches!(name.to_ascii_lowercase().as_str(), "python" | "python3")
-                && directory
-                    .file_name()
-                    .and_then(|value| value.to_str())
-                    .is_some_and(|value| value.eq_ignore_ascii_case("WindowsApps"))
-            {
-                continue;
-            }
-            if candidate.is_file() {
-                return Some(candidate);
-            }
+        let candidate = directory.join(&filename);
+        #[cfg(target_os = "windows")]
+        if matches!(name.to_ascii_lowercase().as_str(), "python" | "python3")
+            && directory
+                .file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|value| value.eq_ignore_ascii_case("WindowsApps"))
+        {
+            continue;
+        }
+        if candidate.is_file() {
+            return Some(candidate);
         }
     }
     None
@@ -405,25 +386,24 @@ fn same_binary(left: &Path, right: &Path) -> bool {
 }
 
 fn find_distinct_system_binary(name: &str, bundled: Option<&Path>) -> Option<PathBuf> {
+    let filename = executable_filename(name);
     for directory in env::split_paths(&command_path()) {
-        for filename in executable_filenames(name) {
-            let candidate = directory.join(filename);
-            #[cfg(target_os = "windows")]
-            if matches!(name.to_ascii_lowercase().as_str(), "python" | "python3")
-                && directory
-                    .file_name()
-                    .and_then(|value| value.to_str())
-                    .is_some_and(|value| value.eq_ignore_ascii_case("WindowsApps"))
-            {
-                continue;
-            }
-            if candidate.is_file()
-                && !bundled
-                    .map(|bundled| same_binary(&candidate, bundled))
-                    .unwrap_or(false)
-            {
-                return Some(candidate);
-            }
+        let candidate = directory.join(&filename);
+        #[cfg(target_os = "windows")]
+        if matches!(name.to_ascii_lowercase().as_str(), "python" | "python3")
+            && directory
+                .file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|value| value.eq_ignore_ascii_case("WindowsApps"))
+        {
+            continue;
+        }
+        if candidate.is_file()
+            && !bundled
+                .map(|bundled| same_binary(&candidate, bundled))
+                .unwrap_or(false)
+        {
+            return Some(candidate);
         }
     }
     None
@@ -464,28 +444,32 @@ fn bundled_binary(app: &AppHandle, name: &str) -> Option<PathBuf> {
     candidates.into_iter().find(|path| path.is_file())
 }
 
-/// BBDown's original CLI keeps web/TV login state beside the executable.  A
-/// user may already have logged in with a standalone `bbdown` command, so
-/// detect that native state before falling back to the bundled copy.  This is
-/// deliberately a structural check only; the CLI remains responsible for
-/// validating expiry and account permissions.
+/// BBDown's original CLI keeps web/TV login state beside the executable. This
+/// small shape check only prevents an old GUI QR ticket from being mistaken for
+/// a native state file; BBDown remains the only code that reads, validates, and
+/// writes the credentials.
+fn bbdown_state_file_is_native(path: &Path, filename: &str) -> bool {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let contents = contents.to_ascii_lowercase();
+    match filename {
+        "BBDown.data" => {
+            contents.contains("sessdata=")
+                && (contents.contains("bili_jct=") || contents.contains("dedeuserid="))
+        }
+        "BBDownTV.data" | "BBDownApp.data" => contents.contains("access_token="),
+        _ => false,
+    }
+}
+
 fn bbdown_has_native_session(executable: &Path) -> bool {
     let Some(parent) = executable.parent() else {
         return false;
     };
-    for filename in ["BBDown.data", "BBDownTV.data", "BBDownApp.data"] {
-        let path = parent.join(filename);
-        let Ok(contents) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        let contents = contents.to_ascii_lowercase();
-        let web_session = contents.contains("sessdata=")
-            && (contents.contains("bili_jct=") || contents.contains("dedeuserid="));
-        if web_session || contents.contains("access_token=") {
-            return true;
-        }
-    }
-    false
+    ["BBDown.data", "BBDownTV.data", "BBDownApp.data"]
+        .iter()
+        .any(|filename| bbdown_state_file_is_native(&parent.join(filename), filename))
 }
 
 fn resolve_tool(app: &AppHandle, tool: &ToolName) -> Option<(PathBuf, bool)> {
@@ -496,18 +480,11 @@ fn resolve_tool(app: &AppHandle, tool: &ToolName) -> Option<(PathBuf, bool)> {
     )
     .map(|path| (path, false));
 
-    // Match the standalone CLI when it already has a native login file. This
-    // keeps `bbdown login` followed by `bbdown <url>` and the GUI on one state
-    // file instead of silently creating a second bundled session.
-    if matches!(tool, ToolName::Bbdown)
-        && system
-            .as_ref()
-            .is_some_and(|(path, _)| bbdown_has_native_session(path))
-    {
-        return system;
-    }
-
-    if matches!(
+    if matches!(tool, ToolName::Bbdown) {
+        // BBDown owns its adjacent BBDown.data file. Keep the bundled binary
+        // and its native state together even when other tools use System mode.
+        bundled.or(system)
+    } else if matches!(
         load_app_settings(app).dependency_preference,
         DependencyPreference::System
     ) {
@@ -822,12 +799,25 @@ fn prepare_bbdown_runtime(app: &AppHandle, bundled: &Path) -> Result<PathBuf, St
         "BBDown.archives",
     ] {
         let target = runtime_dir.join(filename);
-        if target.is_file() {
+        let native_state_file =
+            matches!(filename, "BBDown.data" | "BBDownTV.data" | "BBDownApp.data");
+        if target.is_file()
+            && (!native_state_file || bbdown_state_file_is_native(&target, filename))
+        {
             continue;
+        }
+        // An older GUI version could leave a temporary QR ticket in
+        // BBDown.data. Remove only that invalid state; valid native files are
+        // never touched and BBDown still owns all login writes.
+        if native_state_file && target.is_file() {
+            let _ = std::fs::remove_file(&target);
         }
         for directory in &legacy_dirs {
             let source = directory.join(filename);
-            if source.is_file() && !same_binary(&source, &target) {
+            if source.is_file()
+                && !same_binary(&source, &target)
+                && (!native_state_file || bbdown_state_file_is_native(&source, filename))
+            {
                 let _ = std::fs::copy(&source, &target);
                 if target.is_file() {
                     break;
@@ -1770,12 +1760,7 @@ async fn run_tool(
     }
 
     let working_dir = if matches!(request.tool, ToolName::Bbdown) {
-        let directory = if is_login && !bundled {
-            executable
-                .parent()
-                .map(Path::to_path_buf)
-                .unwrap_or(bbdown_working_dir(&app)?)
-        } else if is_login || request.args.iter().any(|arg| arg == "--work-dir") {
+        let directory = if is_login || request.args.iter().any(|arg| arg == "--work-dir") {
             bbdown_working_dir(&app)?
         } else {
             load_app_settings(&app)
@@ -2784,9 +2769,10 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::{
-        bbdown_has_native_session, codecs_from_probe, is_text_subtitle_file, media_info_summary,
-        musicdl_launcher_python, pr_audio_container, pr_container, redact_output_line,
-        sanitize_diagnostic_text, streams_from_probe, strip_ansi_codes,
+        bbdown_has_native_session, bbdown_state_file_is_native, codecs_from_probe,
+        is_text_subtitle_file, media_info_summary, musicdl_launcher_python, pr_audio_container,
+        pr_container, redact_output_line, sanitize_diagnostic_text, streams_from_probe,
+        strip_ansi_codes,
     };
     use serde_json::json;
     use std::fs;
@@ -2794,7 +2780,7 @@ mod tests {
     use uuid::Uuid;
 
     #[test]
-    fn detects_native_bbdown_session_next_to_standalone_cli() {
+    fn detects_native_bbdown_session_next_to_runtime() {
         let directory = std::env::temp_dir().join(format!("mad-toolbox-bbdown-{}", Uuid::new_v4()));
         fs::create_dir_all(&directory).unwrap();
         let executable = directory.join("BBDown");
@@ -2811,6 +2797,16 @@ mod tests {
         )
         .unwrap();
         assert!(!bbdown_has_native_session(&executable));
+        assert!(!bbdown_state_file_is_native(
+            &directory.join("BBDown.data"),
+            "BBDown.data"
+        ));
+
+        fs::write(directory.join("BBDownTV.data"), "access_token=sample").unwrap();
+        assert!(bbdown_state_file_is_native(
+            &directory.join("BBDownTV.data"),
+            "BBDownTV.data"
+        ));
         fs::remove_dir_all(directory).unwrap();
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -305,6 +305,9 @@ fn command_path() -> OsString {
         }
         if let Some(profile) = env::var_os("USERPROFILE") {
             let profile = PathBuf::from(profile);
+            paths.push(profile.join("Documents").join("apps").join("ffmpeg"));
+            paths.push(profile.join("Documents").join("apps"));
+            paths.push(profile.join("bin"));
             paths.push(profile.join(".local").join("bin"));
             paths.push(profile.join("scoop").join("shims"));
         }
@@ -336,7 +339,11 @@ fn command_path() -> OsString {
     }
     #[cfg(not(target_os = "windows"))]
     if let Some(home) = env::var_os("HOME") {
-        paths.push(PathBuf::from(home).join(".local").join("bin"));
+        let home = PathBuf::from(home);
+        paths.push(home.join("Documents").join("apps").join("ffmpeg"));
+        paths.push(home.join("Documents").join("apps"));
+        paths.push(home.join("bin"));
+        paths.push(home.join(".local").join("bin"));
     }
     if let Ok(current) = env::current_exe() {
         if let Some(parent) = current.parent() {
@@ -355,21 +362,33 @@ fn executable_filename(name: &str) -> String {
     }
 }
 
-fn find_system_binary(name: &str) -> Option<PathBuf> {
-    let filename = executable_filename(name);
-    for directory in env::split_paths(&command_path()) {
-        let candidate = directory.join(&filename);
-        #[cfg(target_os = "windows")]
-        if matches!(name.to_ascii_lowercase().as_str(), "python" | "python3")
-            && directory
-                .file_name()
-                .and_then(|value| value.to_str())
-                .is_some_and(|value| value.eq_ignore_ascii_case("WindowsApps"))
-        {
-            continue;
+fn executable_filenames(name: &str) -> Vec<String> {
+    let primary = executable_filename(name);
+    if name.eq_ignore_ascii_case("bbdown") {
+        let alternate = executable_filename("bbdown");
+        if alternate != primary {
+            return vec![primary, alternate];
         }
-        if candidate.is_file() {
-            return Some(candidate);
+    }
+    vec![primary]
+}
+
+fn find_system_binary(name: &str) -> Option<PathBuf> {
+    for directory in env::split_paths(&command_path()) {
+        for filename in executable_filenames(name) {
+            let candidate = directory.join(filename);
+            #[cfg(target_os = "windows")]
+            if matches!(name.to_ascii_lowercase().as_str(), "python" | "python3")
+                && directory
+                    .file_name()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|value| value.eq_ignore_ascii_case("WindowsApps"))
+            {
+                continue;
+            }
+            if candidate.is_file() {
+                return Some(candidate);
+            }
         }
     }
     None
@@ -386,24 +405,25 @@ fn same_binary(left: &Path, right: &Path) -> bool {
 }
 
 fn find_distinct_system_binary(name: &str, bundled: Option<&Path>) -> Option<PathBuf> {
-    let filename = executable_filename(name);
     for directory in env::split_paths(&command_path()) {
-        let candidate = directory.join(&filename);
-        #[cfg(target_os = "windows")]
-        if matches!(name.to_ascii_lowercase().as_str(), "python" | "python3")
-            && directory
-                .file_name()
-                .and_then(|value| value.to_str())
-                .is_some_and(|value| value.eq_ignore_ascii_case("WindowsApps"))
-        {
-            continue;
-        }
-        if candidate.is_file()
-            && !bundled
-                .map(|bundled| same_binary(&candidate, bundled))
-                .unwrap_or(false)
-        {
-            return Some(candidate);
+        for filename in executable_filenames(name) {
+            let candidate = directory.join(filename);
+            #[cfg(target_os = "windows")]
+            if matches!(name.to_ascii_lowercase().as_str(), "python" | "python3")
+                && directory
+                    .file_name()
+                    .and_then(|value| value.to_str())
+                    .is_some_and(|value| value.eq_ignore_ascii_case("WindowsApps"))
+            {
+                continue;
+            }
+            if candidate.is_file()
+                && !bundled
+                    .map(|bundled| same_binary(&candidate, bundled))
+                    .unwrap_or(false)
+            {
+                return Some(candidate);
+            }
         }
     }
     None
@@ -444,6 +464,30 @@ fn bundled_binary(app: &AppHandle, name: &str) -> Option<PathBuf> {
     candidates.into_iter().find(|path| path.is_file())
 }
 
+/// BBDown's original CLI keeps web/TV login state beside the executable.  A
+/// user may already have logged in with a standalone `bbdown` command, so
+/// detect that native state before falling back to the bundled copy.  This is
+/// deliberately a structural check only; the CLI remains responsible for
+/// validating expiry and account permissions.
+fn bbdown_has_native_session(executable: &Path) -> bool {
+    let Some(parent) = executable.parent() else {
+        return false;
+    };
+    for filename in ["BBDown.data", "BBDownTV.data", "BBDownApp.data"] {
+        let path = parent.join(filename);
+        let Ok(contents) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        let contents = contents.to_ascii_lowercase();
+        let web_session = contents.contains("sessdata=")
+            && (contents.contains("bili_jct=") || contents.contains("dedeuserid="));
+        if web_session || contents.contains("access_token=") {
+            return true;
+        }
+    }
+    false
+}
+
 fn resolve_tool(app: &AppHandle, tool: &ToolName) -> Option<(PathBuf, bool)> {
     let bundled = bundled_binary(app, tool.executable()).map(|path| (path, true));
     let system = find_distinct_system_binary(
@@ -451,6 +495,18 @@ fn resolve_tool(app: &AppHandle, tool: &ToolName) -> Option<(PathBuf, bool)> {
         bundled.as_ref().map(|(path, _)| path.as_path()),
     )
     .map(|path| (path, false));
+
+    // Match the standalone CLI when it already has a native login file. This
+    // keeps `bbdown login` followed by `bbdown <url>` and the GUI on one state
+    // file instead of silently creating a second bundled session.
+    if matches!(tool, ToolName::Bbdown)
+        && system
+            .as_ref()
+            .is_some_and(|(path, _)| bbdown_has_native_session(path))
+    {
+        return system;
+    }
+
     if matches!(
         load_app_settings(app).dependency_preference,
         DependencyPreference::System
@@ -1326,6 +1382,24 @@ async fn dependency_status(app: AppHandle) -> Vec<DependencyStatus> {
 }
 
 #[tauri::command]
+fn bbdown_auth_status(app: AppHandle) -> Result<String, String> {
+    let Some((resolved, bundled)) = resolve_tool(&app, &ToolName::Bbdown) else {
+        return Ok("unknown".into());
+    };
+    let executable = if bundled {
+        prepare_bbdown_runtime(&app, &resolved)?
+    } else {
+        resolved
+    };
+    Ok(if bbdown_has_native_session(&executable) {
+        "authenticated"
+    } else {
+        "unknown"
+    }
+    .into())
+}
+
+#[tauri::command]
 fn export_job_log(request: LogExportRequest) -> Result<DiagnosticExportResult, String> {
     let output = PathBuf::from(request.output_path);
     let parent = output
@@ -1696,7 +1770,12 @@ async fn run_tool(
     }
 
     let working_dir = if matches!(request.tool, ToolName::Bbdown) {
-        let directory = if is_login || request.args.iter().any(|arg| arg == "--work-dir") {
+        let directory = if is_login && !bundled {
+            executable
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or(bbdown_working_dir(&app)?)
+        } else if is_login || request.args.iter().any(|arg| arg == "--work-dir") {
             bbdown_working_dir(&app)?
         } else {
             load_app_settings(&app)
@@ -2684,6 +2763,7 @@ pub fn run() {
             app_settings,
             save_app_settings,
             dependency_status,
+            bbdown_auth_status,
             export_job_log,
             export_job_diagnostics,
             ffmpeg_encoders,
@@ -2704,12 +2784,35 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::{
-        codecs_from_probe, is_text_subtitle_file, media_info_summary, musicdl_launcher_python,
-        pr_audio_container, pr_container, redact_output_line, sanitize_diagnostic_text,
-        streams_from_probe, strip_ansi_codes,
+        bbdown_has_native_session, codecs_from_probe, is_text_subtitle_file, media_info_summary,
+        musicdl_launcher_python, pr_audio_container, pr_container, redact_output_line,
+        sanitize_diagnostic_text, streams_from_probe, strip_ansi_codes,
     };
     use serde_json::json;
+    use std::fs;
     use std::path::Path;
+    use uuid::Uuid;
+
+    #[test]
+    fn detects_native_bbdown_session_next_to_standalone_cli() {
+        let directory = std::env::temp_dir().join(format!("mad-toolbox-bbdown-{}", Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        let executable = directory.join("BBDown");
+        fs::write(
+            directory.join("BBDown.data"),
+            "DedeUserID=123;SESSDATA=sample;bili_jct=csrf;",
+        )
+        .unwrap();
+        assert!(bbdown_has_native_session(&executable));
+
+        fs::write(
+            directory.join("BBDown.data"),
+            "ticket=temporary;gourl=login;",
+        )
+        .unwrap();
+        assert!(!bbdown_has_native_session(&executable));
+        fs::remove_dir_all(directory).unwrap();
+    }
 
     #[test]
     fn redacts_bilibili_credentials_from_process_output() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MAD Toolbox",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "identifier": "org.madproducer.toolbox",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/hooks/useBackend.ts
+++ b/src/hooks/useBackend.ts
@@ -84,6 +84,11 @@ export function useBackend() {
         const without = current.filter((job) => job.jobId !== payload.jobId);
         return [payload, ...without].slice(0, 200);
       });
+      if (payload.tool === "bbdown" && payload.state !== "running") {
+        void invoke<BbdownAuthStatus>("bbdown_auth_status")
+          .then((status) => setBbdownAuthStatus(status))
+          .catch(() => setBbdownAuthStatus("unknown"));
+      }
       if (payload.state !== "running") {
         setLoginQr((current) => (current?.jobId === payload.jobId ? null : current));
       }

--- a/src/hooks/useBackend.ts
+++ b/src/hooks/useBackend.ts
@@ -54,6 +54,9 @@ export function useBackend() {
   useEffect(() => {
     void refreshDependencies();
     void refreshSettings();
+    void invoke<BbdownAuthStatus>("bbdown_auth_status")
+      .then((status) => setBbdownAuthStatus(status))
+      .catch(() => setBbdownAuthStatus("unknown"));
     const unlistenLog = listen<JobLog>("job-log", ({ payload }) => {
       setLogs((current) => [...current.slice(-4999), payload]);
       if (payload.tool === "bbdown") {

--- a/src/pages/BilibiliPage.tsx
+++ b/src/pages/BilibiliPage.tsx
@@ -86,7 +86,7 @@ export function BilibiliPage({
   const authCopy = {
     unknown: {
       title: "登录状态待检测",
-      hint: "优先沿用终端 bbdown 已保存的原生状态；没有时再扫码登录。",
+      hint: "点击扫码登录，BBDown 会按原生方式保存并读取登录状态。",
       button: "扫码登录"
     },
     authenticated: {

--- a/src/pages/BilibiliPage.tsx
+++ b/src/pages/BilibiliPage.tsx
@@ -86,11 +86,11 @@ export function BilibiliPage({
   const authCopy = {
     unknown: {
       title: "登录状态待检测",
-      hint: "点击扫码登录，BBDown 会按原生方式保存并读取登录状态。",
+      hint: "优先沿用终端 bbdown 已保存的原生状态；没有时再扫码登录。",
       button: "扫码登录"
     },
     authenticated: {
-      title: "已检测到哔哩哔哩登录",
+      title: "已检测到 BBDown 登录状态",
       hint: "BBDown 已取得账号权限，最终画质仍取决于账号和视频本身。",
       button: "重新登录"
     },


### PR DESCRIPTION
## What changed

- Keep Full and Lite BBDown on the bundled executable and one private runtime directory on macOS and Windows.
- Make login and later downloads use the same executable directory, so BBDown itself reads and writes its native `BBDown.data`.
- Ignore the 103-byte temporary QR ticket left by an older GUI build; valid native BBDown state is preserved and legacy bundled state can be migrated.
- Keep the GUI login indicator read-only; it does not parse, encrypt, inject, or store credentials.
- Bump the app to 0.5.8.

## Root cause

The reported download log showed `加载本地cookie`, but the bundled runtime file was only a 103-byte `ticket=...` QR ticket, not a successful native Cookie file. BBDown therefore read the file and correctly reported that the account was not logged in, which limited the streams to 480P. The previous draft implementation incorrectly tried to select a standalone BBDown from user directories; this revision removes that behavior.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml` (12 passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `npm run check`
- `npm run build`
