### PR TITLE
fix: use native BBDown login state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to MAD Toolbox are documented here.
 
+## 0.5.9 - 2026-08-02
+
+- Run the bundled BBDown directly from its own application directory so its
+  native `BBDown.data` and login overwrite behavior remain untouched. The GUI
+  no longer copies BBDown or migrates data from any other installation.
+- Rebuilt the bundled macOS BBDown with only the GUI-safe login adjustment:
+  BBDown still performs the QR polling and writes its native data file, while
+  its unused platform cookie container and terminal QR renderer are skipped.
+
 ## 0.5.8 - 2026-08-01
 
 - Fixed bundled BBDown login state on macOS and Windows when an older GUI left

--- a/docs/FULL_BUILD.md
+++ b/docs/FULL_BUILD.md
@@ -35,7 +35,10 @@ configure flags and configure output. Never package an `--enable-nonfree`
 build.
 
 The macOS tool pack and reproducible arm64 build procedure are pinned in
-`third_party/sources.json` and `third_party/build/`.
+`third_party/sources.json` and `third_party/build/`. The bundled macOS BBDown
+binary carries the small patch listed there: its native login still writes and
+reads `BBDown.data`, disables the unused platform cookie container, and skips
+terminal QR rendering because MAD Toolbox displays `qrcode.png` in the GUI.
 
 The Windows tool pack is pinned in `third_party/windows-sources.json`. Run
 `scripts/prepare-windows-tools.ps1 -Edition Full` to download missing official

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -1,6 +1,6 @@
 # Windows x64 build
 
-MAD Toolbox 0.5.8 targets Windows 10 22H2 and Windows 11 on Intel/AMD x64
+MAD Toolbox 0.5.9 targets Windows 10 22H2 and Windows 11 on Intel/AMD x64
 processors (`x86_64-pc-windows-msvc`). ARM64 and 32-bit x86 installers are not
 currently produced.
 
@@ -42,13 +42,11 @@ The output is a per-user bilingual NSIS installer.
 
 ## CLI state and diagnostics
 
-The bundled BBDown is copied to the per-user application data directory at
-first use, with its native `BBDown.data` kept beside that runtime copy. Login
-and later downloads always run this same bundled executable, so BBDown reads
-and writes its own file exactly as in the original CLI. An old temporary QR
-ticket is ignored once and a valid native file beside an older bundled
-executable can be migrated. The GUI does not parse, encrypt, or inject the
-credentials.
+The bundled BBDown is launched directly from the directory shipped inside the
+application. Login and later downloads use that same executable and working
+directory, so BBDown reads and writes `BBDown.data` exactly as in the original
+CLI. The GUI does not copy, parse, encrypt, migrate or inject credentials, and
+it never launches a separately installed BBDown.
 
 MAD Toolbox does not parse, encrypt or inject this native state and does not
 use Credential Manager. Templates are ordinary WebView application data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mad-toolbox",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mad-toolbox",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mad-toolbox",
   "private": true,
-  "version": "0.5.8",
+  "version": "0.5.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/verify-bundled-tools.sh
+++ b/scripts/verify-bundled-tools.sh
@@ -20,7 +20,7 @@ binary_directory="src-tauri/binaries"
 suffix="aarch64-apple-darwin"
 
 verify_checksum "$binary_directory/BBDown-$suffix" \
-  "33597b2b7b83eecb4fbb4f0a50a43f1ada3ac1d9b6adf4eadda8399c700ea470"
+  "f60cb75a09447e3df0ac332469accaeff36d8215b042f9bcfbf9e00d00ef86ac"
 verify_checksum "$binary_directory/ffmpeg-$suffix" \
   "ee4226e41c6f018affcf2c62e683a35d132b18eb16de364448a035afb548939e"
 verify_checksum "$binary_directory/ffprobe-$suffix" \

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "mad-toolbox"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mad-toolbox"
-version = "0.5.8"
+version = "0.5.9"
 description = "A GUI toolbox for BBDown, yt-dlp, FFmpeg and MediaInfo"
 authors = ["MAD Toolbox Contributors"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -444,34 +444,6 @@ fn bundled_binary(app: &AppHandle, name: &str) -> Option<PathBuf> {
     candidates.into_iter().find(|path| path.is_file())
 }
 
-/// BBDown's original CLI keeps web/TV login state beside the executable. This
-/// small shape check only prevents an old GUI QR ticket from being mistaken for
-/// a native state file; BBDown remains the only code that reads, validates, and
-/// writes the credentials.
-fn bbdown_state_file_is_native(path: &Path, filename: &str) -> bool {
-    let Ok(contents) = std::fs::read_to_string(path) else {
-        return false;
-    };
-    let contents = contents.to_ascii_lowercase();
-    match filename {
-        "BBDown.data" => {
-            contents.contains("sessdata=")
-                && (contents.contains("bili_jct=") || contents.contains("dedeuserid="))
-        }
-        "BBDownTV.data" | "BBDownApp.data" => contents.contains("access_token="),
-        _ => false,
-    }
-}
-
-fn bbdown_has_native_session(executable: &Path) -> bool {
-    let Some(parent) = executable.parent() else {
-        return false;
-    };
-    ["BBDown.data", "BBDownTV.data", "BBDownApp.data"]
-        .iter()
-        .any(|filename| bbdown_state_file_is_native(&parent.join(filename), filename))
-}
-
 fn resolve_tool(app: &AppHandle, tool: &ToolName) -> Option<(PathBuf, bool)> {
     let bundled = bundled_binary(app, tool.executable()).map(|path| (path, true));
     let system = find_distinct_system_binary(
@@ -481,9 +453,10 @@ fn resolve_tool(app: &AppHandle, tool: &ToolName) -> Option<(PathBuf, bool)> {
     .map(|path| (path, false));
 
     if matches!(tool, ToolName::Bbdown) {
-        // BBDown owns its adjacent BBDown.data file. Keep the bundled binary
-        // and its native state together even when other tools use System mode.
-        bundled.or(system)
+        // Full/Lite both ship BBDown. Never silently switch to a separately
+        // installed copy: BBDown must read and write the data file beside the
+        // executable included in this app.
+        bundled
     } else if matches!(
         load_app_settings(app).dependency_preference,
         DependencyPreference::System
@@ -752,129 +725,14 @@ fn save_app_settings(app: AppHandle, mut settings: AppSettings) -> Result<AppSet
     Ok(settings)
 }
 
-fn bbdown_working_dir(app: &AppHandle) -> Result<PathBuf, String> {
-    let path = app_data_dir(app)?.join("bbdown");
-    std::fs::create_dir_all(&path).map_err(|error| error.to_string())?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))
-            .map_err(|error| error.to_string())?;
-    }
-    Ok(path)
-}
-
-/// BBDown 1.6.3 stores BBDown.data beside its own executable (Program.APP_DIR),
-/// not beside the download output directory.  A bundled executable inside an
-/// installed app is not a reliable place for a user-writable session file,
-/// especially on Windows and signed macOS app bundles.  Run a private copy from
-/// the app-data directory so login and download always share the same native
-/// BBDown files on both platforms.
-fn prepare_bbdown_runtime(app: &AppHandle, bundled: &Path) -> Result<PathBuf, String> {
-    let runtime_dir = bbdown_working_dir(app)?;
-    let runtime_binary = runtime_dir.join(executable_filename("BBDown"));
-
-    // Preserve files created by the original CLI, including an existing login,
-    // config, and archive file next to a previously bundled executable.
-    let mut legacy_dirs = Vec::new();
-    if let Some(parent) = bundled.parent() {
-        legacy_dirs.push(parent.to_path_buf());
-    }
-    if let Ok(resources) = app.path().resource_dir() {
-        legacy_dirs.push(resources.clone());
-        legacy_dirs.push(resources.join("binaries"));
-    }
-    if let Ok(current) = env::current_exe() {
-        if let Some(parent) = current.parent() {
-            legacy_dirs.push(parent.to_path_buf());
-        }
-    }
-    legacy_dirs.sort();
-    legacy_dirs.dedup();
-    for filename in [
-        "BBDown.data",
-        "BBDownTV.data",
-        "BBDownApp.data",
-        "BBDown.config",
-        "BBDown.archives",
-    ] {
-        let target = runtime_dir.join(filename);
-        let native_state_file =
-            matches!(filename, "BBDown.data" | "BBDownTV.data" | "BBDownApp.data");
-        if target.is_file()
-            && (!native_state_file || bbdown_state_file_is_native(&target, filename))
-        {
-            continue;
-        }
-        // An older GUI version could leave a temporary QR ticket in
-        // BBDown.data. Remove only that invalid state; valid native files are
-        // never touched and BBDown still owns all login writes.
-        if native_state_file && target.is_file() {
-            let _ = std::fs::remove_file(&target);
-        }
-        for directory in &legacy_dirs {
-            let source = directory.join(filename);
-            if source.is_file()
-                && !same_binary(&source, &target)
-                && (!native_state_file || bbdown_state_file_is_native(&source, filename))
-            {
-                let _ = std::fs::copy(&source, &target);
-                if target.is_file() {
-                    break;
-                }
-            }
-        }
-    }
-
-    // The bundled BBDown is a self-contained executable.  Copy it once (or
-    // refresh it when the packaged size changes) into the same directory as
-    // BBDown.data.  If Windows has an older runtime process open, retain the
-    // already working copy instead of breaking a new task.
-    let source_size = std::fs::metadata(bundled)
-        .map_err(|error| format!("无法读取 BBDown：{error}"))?
-        .len();
-    let needs_copy = !runtime_binary.is_file()
-        || std::fs::metadata(&runtime_binary)
-            .map(|metadata| metadata.len() != source_size)
-            .unwrap_or(true);
-    if needs_copy {
-        let temporary = runtime_dir.join(format!(".BBDown-{}.tmp", Uuid::new_v4()));
-        let copy_result = (|| {
-            std::fs::copy(bundled, &temporary)
-                .map_err(|error| format!("无法准备 BBDown：{error}"))?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let mode = std::fs::metadata(bundled)
-                    .map_err(|error| format!("无法读取 BBDown 权限：{error}"))?
-                    .permissions()
-                    .mode();
-                std::fs::set_permissions(&temporary, std::fs::Permissions::from_mode(mode | 0o111))
-                    .map_err(|error| format!("无法设置 BBDown 权限：{error}"))?;
-            }
-            if runtime_binary.is_file() {
-                std::fs::remove_file(&runtime_binary)
-                    .map_err(|error| format!("无法更新 BBDown：{error}"))?;
-            }
-            std::fs::rename(&temporary, &runtime_binary)
-                .map_err(|error| format!("无法保存 BBDown：{error}"))?;
-            Ok::<(), String>(())
-        })();
-        if copy_result.is_err() {
-            let _ = std::fs::remove_file(&temporary);
-            if !runtime_binary.is_file() {
-                return Err(copy_result
-                    .err()
-                    .unwrap_or_else(|| "无法准备 BBDown 运行文件".into()));
-            }
-        }
-    }
-
-    if runtime_binary.is_file() {
-        Ok(runtime_binary)
-    } else {
-        Err("无法准备 BBDown 运行文件".into())
-    }
+/// BBDown's own `Program.APP_DIR` is the directory containing the executable.
+/// Run it from that directory so its native `BBDown.data`, config, archive and
+/// QR files stay exactly where the original CLI expects them.
+fn bbdown_directory(executable: &Path) -> Result<PathBuf, String> {
+    executable
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| "无法确定 BBDown 所在目录".to_string())
 }
 
 fn strip_ansi_codes(line: &str) -> String {
@@ -1372,24 +1230,6 @@ async fn dependency_status(app: AppHandle) -> Vec<DependencyStatus> {
 }
 
 #[tauri::command]
-fn bbdown_auth_status(app: AppHandle) -> Result<String, String> {
-    let Some((resolved, bundled)) = resolve_tool(&app, &ToolName::Bbdown) else {
-        return Ok("unknown".into());
-    };
-    let executable = if bundled {
-        prepare_bbdown_runtime(&app, &resolved)?
-    } else {
-        resolved
-    };
-    Ok(if bbdown_has_native_session(&executable) {
-        "authenticated"
-    } else {
-        "unknown"
-    }
-    .into())
-}
-
-#[tauri::command]
 fn export_job_log(request: LogExportRequest) -> Result<DiagnosticExportResult, String> {
     let output = PathBuf::from(request.output_path);
     let parent = output
@@ -1736,13 +1576,9 @@ async fn run_tool(
     state: State<'_, AppState>,
     mut request: RunRequest,
 ) -> Result<RunResult, String> {
-    let (resolved_executable, bundled) = resolve_tool(&app, &request.tool)
+    let (resolved_executable, _bundled) = resolve_tool(&app, &request.tool)
         .ok_or_else(|| format!("未找到 {}，请先安装依赖", request.tool.label()))?;
-    let executable = if matches!(request.tool, ToolName::Bbdown) && bundled {
-        prepare_bbdown_runtime(&app, &resolved_executable)?
-    } else {
-        resolved_executable
-    };
+    let executable = resolved_executable;
     let is_login = matches!(request.tool, ToolName::Bbdown)
         && request.args.first().map(String::as_str) == Some("login");
     if matches!(request.tool, ToolName::YtDlp)
@@ -1760,17 +1596,7 @@ async fn run_tool(
     }
 
     let working_dir = if matches!(request.tool, ToolName::Bbdown) {
-        let directory = if is_login || request.args.iter().any(|arg| arg == "--work-dir") {
-            bbdown_working_dir(&app)?
-        } else {
-            load_app_settings(&app)
-                .default_output_directory
-                .map(PathBuf::from)
-                .filter(|path| path.is_dir())
-                .or_else(|| app.path().download_dir().ok())
-                .unwrap_or(bbdown_working_dir(&app)?)
-        };
-        Some(directory)
+        Some(bbdown_directory(&executable)?)
     } else {
         request.working_dir.map(PathBuf::from)
     };
@@ -2748,7 +2574,6 @@ pub fn run() {
             app_settings,
             save_app_settings,
             dependency_status,
-            bbdown_auth_status,
             export_job_log,
             export_job_diagnostics,
             ffmpeg_encoders,
@@ -2769,46 +2594,12 @@ pub fn run() {
 #[cfg(test)]
 mod tests {
     use super::{
-        bbdown_has_native_session, bbdown_state_file_is_native, codecs_from_probe,
-        is_text_subtitle_file, media_info_summary, musicdl_launcher_python, pr_audio_container,
-        pr_container, redact_output_line, sanitize_diagnostic_text, streams_from_probe,
-        strip_ansi_codes,
+        codecs_from_probe, is_text_subtitle_file, media_info_summary, musicdl_launcher_python,
+        pr_audio_container, pr_container, redact_output_line, sanitize_diagnostic_text,
+        streams_from_probe, strip_ansi_codes,
     };
     use serde_json::json;
-    use std::fs;
     use std::path::Path;
-    use uuid::Uuid;
-
-    #[test]
-    fn detects_native_bbdown_session_next_to_runtime() {
-        let directory = std::env::temp_dir().join(format!("mad-toolbox-bbdown-{}", Uuid::new_v4()));
-        fs::create_dir_all(&directory).unwrap();
-        let executable = directory.join("BBDown");
-        fs::write(
-            directory.join("BBDown.data"),
-            "DedeUserID=123;SESSDATA=sample;bili_jct=csrf;",
-        )
-        .unwrap();
-        assert!(bbdown_has_native_session(&executable));
-
-        fs::write(
-            directory.join("BBDown.data"),
-            "ticket=temporary;gourl=login;",
-        )
-        .unwrap();
-        assert!(!bbdown_has_native_session(&executable));
-        assert!(!bbdown_state_file_is_native(
-            &directory.join("BBDown.data"),
-            "BBDown.data"
-        ));
-
-        fs::write(directory.join("BBDownTV.data"), "access_token=sample").unwrap();
-        assert!(bbdown_state_file_is_native(
-            &directory.join("BBDownTV.data"),
-            "BBDownTV.data"
-        ));
-        fs::remove_dir_all(directory).unwrap();
-    }
 
     #[test]
     fn redacts_bilibili_credentials_from_process_output() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MAD Toolbox",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "identifier": "org.madproducer.toolbox",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/hooks/useBackend.ts
+++ b/src/hooks/useBackend.ts
@@ -54,9 +54,6 @@ export function useBackend() {
   useEffect(() => {
     void refreshDependencies();
     void refreshSettings();
-    void invoke<BbdownAuthStatus>("bbdown_auth_status")
-      .then((status) => setBbdownAuthStatus(status))
-      .catch(() => setBbdownAuthStatus("unknown"));
     const unlistenLog = listen<JobLog>("job-log", ({ payload }) => {
       setLogs((current) => [...current.slice(-4999), payload]);
       if (payload.tool === "bbdown") {
@@ -84,11 +81,6 @@ export function useBackend() {
         const without = current.filter((job) => job.jobId !== payload.jobId);
         return [payload, ...without].slice(0, 200);
       });
-      if (payload.tool === "bbdown" && payload.state !== "running") {
-        void invoke<BbdownAuthStatus>("bbdown_auth_status")
-          .then((status) => setBbdownAuthStatus(status))
-          .catch(() => setBbdownAuthStatus("unknown"));
-      }
       if (payload.state !== "running") {
         setLoginQr((current) => (current?.jobId === payload.jobId ? null : current));
       }

--- a/third_party/patches/BBDown-macos-gui-login.patch
+++ b/third_party/patches/BBDown-macos-gui-login.patch
@@ -1,0 +1,21 @@
+diff --git a/BBDown.Core/Util/HTTPUtil.cs b/BBDown.Core/Util/HTTPUtil.cs
+index 77342c4..54f23e5 100644
+--- a/BBDown.Core/Util/HTTPUtil.cs
++++ b/BBDown.Core/Util/HTTPUtil.cs
+@@ -14,0 +15,4 @@ namespace BBDown.Core.Util
++            // BBDown always sends its cookie string in the request headers.
++            // Avoid creating the platform CookieContainer, which fails in
++            // NativeAOT GUI processes that do not have a local domain name.
++            UseCookies = false,
+diff --git a/BBDown/BBDownLoginUtil.cs b/BBDown/BBDownLoginUtil.cs
+index 1d3aac2..17c6653 100644
+--- a/BBDown/BBDownLoginUtil.cs
++++ b/BBDown/BBDownLoginUtil.cs
+@@ -39,2 +39 @@ namespace BBDown
+-                var consoleQRCode = new ConsoleQRCode(qrCodeData);
+-                consoleQRCode.GetGraphic();
++                // The GUI consumes qrcode.png; do not render a terminal QR code.
+@@ -96,2 +95 @@ namespace BBDown
+-                var consoleQRCode = new ConsoleQRCode(qrCodeData);
+-                consoleQRCode.GetGraphic();
++                // The GUI consumes qrcode.png; do not render a terminal QR code.

--- a/third_party/sources.json
+++ b/third_party/sources.json
@@ -13,7 +13,9 @@
       "artifactUrl": "https://sourceforge.net/projects/bbdown.mirror/files/1.6.3/BBDown_1.6.3_20240814_osx-arm64.zip/download",
       "sourceUrl": "https://sourceforge.net/projects/bbdown.mirror/files/1.6.3/BBDown%20v1.6.3%20source%20code.tar.gz/download",
       "artifactSha256": "4df84014d818bd6dff2b365b847645340e8955c4450fe965688f41af89a38baa",
-      "binarySha256": "33597b2b7b83eecb4fbb4f0a50a43f1ada3ac1d9b6adf4eadda8399c700ea470",
+      "binarySha256": "f60cb75a09447e3df0ac332469accaeff36d8215b042f9bcfbf9e00d00ef86ac",
+      "patchedFromBinarySha256": "33597b2b7b83eecb4fbb4f0a50a43f1ada3ac1d9b6adf4eadda8399c700ea470",
+      "patch": "third_party/patches/BBDown-macos-gui-login.patch",
       "license": "MIT",
       "licenseFiles": ["third_party/licenses/BBDown-MIT.txt"],
       "upstreamArchived": true


### PR DESCRIPTION
## What changed
- run the bundled BBDown directly from its shipped directory on macOS and Windows
- remove GUI-side BBDown.data detection, copying, migration, encryption, and system-BBDown fallback
- keep native BBDown login/download behavior and adjacent BBDown.data state
- fix the bundled macOS NativeAOT login crash caused by CookieContainer initialization and suppress terminal QR rendering
- bump the app to v0.5.9 and keep Full build metadata/checksums in sync

## Root cause
The bundled macOS NativeAOT BBDown failed while initializing the platform CookieContainer before it could create the QR code. BBDown already sends its cookie value in request headers, so the GUI-safe fix disables the unused automatic container while leaving BBDown's native file handling intact.

## Validation
- npm run check
- npm run build
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo test --manifest-path src-tauri/Cargo.toml --locked
- bash scripts/verify-bundled-tools.sh
- upstream BBDown patch dry-run
- macOS Full Tauri app build