### PR TITLE
fix: refresh Windows FFmpeg asset pin

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -22,7 +22,7 @@ endorsed by the original BBDown author.
 - Project: FFmpeg
 - Website: https://ffmpeg.org/
 - macOS version: 8.1.2
-- Windows version: n8.1 latest (2026-07-31)
+- Windows version: n8.1 latest (2026-08-02)
 - License: LGPL-2.1-or-later (macOS) / LGPL-3.0-or-later (Windows build)
 - macOS source: https://ffmpeg.org/releases/ffmpeg-8.1.2.tar.xz
 - Windows source commit: https://github.com/FFmpeg/FFmpeg/commit/9b6c8969e05b4f0b29f0f85cd501be6b3e582e6b

--- a/scripts/prepare-windows-tools.ps1
+++ b/scripts/prepare-windows-tools.ps1
@@ -78,9 +78,9 @@ try {
     $FfmpegDestination = Join-Path $BinaryRoot "ffmpeg-$Target.exe"
     $FfprobeDestination = Join-Path $BinaryRoot "ffprobe-$Target.exe"
     $FfmpegValid = (Test-Path -LiteralPath $FfmpegDestination -PathType Leaf) -and `
-      ((Get-FileHash -LiteralPath $FfmpegDestination -Algorithm SHA256).Hash.ToLowerInvariant() -eq "6099366f31293cdc6c283ea44ffb32f07e3139cd0caf6d0db652a7d064d089cb")
+      ((Get-FileHash -LiteralPath $FfmpegDestination -Algorithm SHA256).Hash.ToLowerInvariant() -eq "0df0daa264f1c6a6dd6e41a0b931b58050726194ee25c18f5e31843545e70e46")
     $FfprobeValid = (Test-Path -LiteralPath $FfprobeDestination -PathType Leaf) -and `
-      ((Get-FileHash -LiteralPath $FfprobeDestination -Algorithm SHA256).Hash.ToLowerInvariant() -eq "4c2f730969c9551aec21c5ca07eb73f63bb0920204c9cd6c9a6e7be6be0458d2")
+      ((Get-FileHash -LiteralPath $FfprobeDestination -Algorithm SHA256).Hash.ToLowerInvariant() -eq "4a745d4c13cc672b4c84f80cb4fa4af1c32f189d02ef500d076161e06a27d20e")
     if (-not ($FfmpegValid -and $FfprobeValid)) {
       $Archive = Join-Path $TemporaryRoot "ffmpeg.zip"
       $Expanded = Join-Path $TemporaryRoot "ffmpeg"
@@ -89,9 +89,9 @@ try {
         "X-GitHub-Api-Version" = "2022-11-28"
       }
       Get-VerifiedFile `
-        -Url "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/assets/496789330" `
+        -Url "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/assets/498933268" `
         -Output $Archive `
-        -Sha256 "a8c13448b26bcee24d22559324d6364173c16f9a85e36bb3642840622bec0f2a" `
+        -Sha256 "53f717ef88d5073c06fb57531af5be7fb6a0703cf1ef4d067a47b169ab9c9d3b" `
         -Headers $Headers
       Expand-VerifiedArchive -Archive $Archive -Destination $Expanded
       $Bin = Get-ChildItem -LiteralPath $Expanded -Filter "ffmpeg.exe" -File -Recurse | Select-Object -First 1
@@ -102,8 +102,8 @@ try {
       Copy-Item -LiteralPath $Bin.FullName -Destination $FfmpegDestination -Force
       Copy-Item -LiteralPath $Probe.FullName -Destination $FfprobeDestination -Force
     }
-    Assert-Hash -Path $FfmpegDestination -Expected "6099366f31293cdc6c283ea44ffb32f07e3139cd0caf6d0db652a7d064d089cb"
-    Assert-Hash -Path $FfprobeDestination -Expected "4c2f730969c9551aec21c5ca07eb73f63bb0920204c9cd6c9a6e7be6be0458d2"
+    Assert-Hash -Path $FfmpegDestination -Expected "0df0daa264f1c6a6dd6e41a0b931b58050726194ee25c18f5e31843545e70e46"
+    Assert-Hash -Path $FfprobeDestination -Expected "4a745d4c13cc672b4c84f80cb4fa4af1c32f189d02ef500d076161e06a27d20e"
 
     $YtDlpDestination = Join-Path $BinaryRoot "yt-dlp-$Target.exe"
     Install-VerifiedBinary `

--- a/scripts/verify-windows-tools.ps1
+++ b/scripts/verify-windows-tools.ps1
@@ -19,11 +19,11 @@ if ($Edition -eq "Full") {
   $Files += @(
     [pscustomobject]@{
       Name = "ffmpeg-$Target.exe"
-      Sha256 = "6099366f31293cdc6c283ea44ffb32f07e3139cd0caf6d0db652a7d064d089cb"
+      Sha256 = "0df0daa264f1c6a6dd6e41a0b931b58050726194ee25c18f5e31843545e70e46"
     },
     [pscustomobject]@{
       Name = "ffprobe-$Target.exe"
-      Sha256 = "4c2f730969c9551aec21c5ca07eb73f63bb0920204c9cd6c9a6e7be6be0458d2"
+      Sha256 = "4a745d4c13cc672b4c84f80cb4fa4af1c32f189d02ef500d076161e06a27d20e"
     },
     [pscustomobject]@{
       Name = "mediainfo-$Target.exe"

--- a/third_party/windows-sources.json
+++ b/third_party/windows-sources.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-07-29",
+  "generatedAt": "2026-08-02",
   "target": "x86_64-pc-windows-msvc",
   "minimumWindowsVersion": "10.0.19045",
   "tools": [
@@ -18,16 +18,16 @@
     },
     {
       "name": "FFmpeg and ffprobe",
-      "version": "n8.1 latest (2026-07-31)",
+      "version": "n8.1 latest (2026-08-02)",
       "bundledIn": ["full"],
       "distribution": "BtbN FFmpeg-Builds win64 LGPL static",
       "artifact": "ffmpeg-n8.1-latest-win64-lgpl-8.1.zip",
       "artifactUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-win64-lgpl-8.1.zip",
-      "releaseAssetApiUrl": "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/assets/496789330",
-      "artifactSha256": "a8c13448b26bcee24d22559324d6364173c16f9a85e36bb3642840622bec0f2a",
+      "releaseAssetApiUrl": "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/assets/498933268",
+      "artifactSha256": "53f717ef88d5073c06fb57531af5be7fb6a0703cf1ef4d067a47b169ab9c9d3b",
       "binarySha256": {
-        "ffmpeg": "6099366f31293cdc6c283ea44ffb32f07e3139cd0caf6d0db652a7d064d089cb",
-        "ffprobe": "4c2f730969c9551aec21c5ca07eb73f63bb0920204c9cd6c9a6e7be6be0458d2"
+        "ffmpeg": "0df0daa264f1c6a6dd6e41a0b931b58050726194ee25c18f5e31843545e70e46",
+        "ffprobe": "4a745d4c13cc672b4c84f80cb4fa4af1c32f189d02ef500d076161e06a27d20e"
       },
       "ffmpegCommit": "9b6c8969e05b4f0b29f0f85cd501be6b3e582e6b",
       "sourceUrl": "https://github.com/FFmpeg/FFmpeg/archive/9b6c8969e05b4f0b29f0f85cd501be6b3e582e6b.tar.gz",


### PR DESCRIPTION
The v0.5.9 Windows Full packaging job hit a 404 because the pinned BtbN release asset ID was retired. This updates the asset ID, archive digest, ffmpeg/ffprobe hashes, and notices to the current 2026-08-02 n8.1 Windows LGPL build.

Validation: JSON metadata parsing, staged diff check, and current archive/hash verification against the GitHub release asset.