### PR TITLE
修复 Issue #10、#17、#18：Cookie 兜底、移除自定义 Logo、Lite 安装弹窗

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 All notable changes to MAD Toolbox are documented here.
 
+## 0.5.12 - Pre-release (2026-08-12)
+
+- 移除设置中的自定义 Logo 功能，应用界面统一使用正式图标，避免只修改局部界面而造成误解。
+- 增加 yt-dlp 的浏览器 Cookie 失败兜底：先执行无 Cookie 请求，只有检测到需要登录或人机验证时，才在同一任务中使用所选浏览器 Cookie 自动重试。
+- 修复 Windows Lite 安装包的 WebView2 setup 流程：Lite 不再内置或启动 WebView2 安装器，使用系统已有 Runtime；Full 继续保留离线安装能力。
+
 ## 0.5.11 - Pre-release (2026-08-11)
 
 - Added an explicit browser Cookie selector for YouTube downloads, including
   Windows Edge/Chrome presets and custom browser profiles. This makes the
   `Sign in to confirm you're not a bot` recovery path visible in the normal
   download workflow without storing Cookie values in MAD Toolbox.
-- Added a local, restart-persistent interface Logo selector for third-party
-  PNG/JPEG/WebP designs while keeping the signed application icon unchanged.
 - Made YouTube connectivity checks resolve `curl` through the application PATH
   on every supported platform instead of relying on a fixed Unix path.
 - Tightened tag-build validation: Windows and macOS release builds now run the

--- a/README.en.md
+++ b/README.en.md
@@ -26,7 +26,8 @@ that can be exported from Task Center.
 - BBDown Bilibili downloads that follow the original CLI behavior, with
   beginner presets and advanced CLI parameters.
 - yt-dlp downloads with YouTube reachability testing, global-proxy guidance,
-  explicit HTTP/HTTPS/SOCKS proxy settings and advanced format controls.
+  explicit HTTP/HTTPS/SOCKS proxy settings, browser-Cookie fallback and
+  advanced format controls.
 - FFmpeg media processing with drag-and-drop files or folders, localized
   MediaInfo inspection, remuxing, stream extraction, ASS/SRT subtitles,
   conversion, bitrate/frame-rate/scaling controls, GIFs and image sequences.
@@ -78,6 +79,11 @@ winget install --id yt-dlp.yt-dlp -e
 winget install --id MediaArea.MediaInfo.CLI -e
 winget install --id DenoLand.Deno -e
 ```
+
+The Windows Lite installer does not embed or launch a WebView2 installer. It
+uses the system WebView2 Runtime, which is normally available on Windows 10
+22H2 and Windows 11. If the runtime is missing, install it separately or use
+the Full build, which includes the offline installer.
 
 ### Full
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Silicon 设备。暂不提供 Windows 32 位和 ARM64 安装包。
   字幕等简易模式，同时尽量覆盖 BBDown 高级参数。支持扫码登录并使用当前
   账号可用的下载规格。
 - 网络视频下载：使用 yt-dlp，自动测试 YouTube 连通性，提示开启全局代理或
-  填写 HTTP、HTTPS、SOCKS 代理，并提供格式、字幕、Cookie 等高级设置。
+  填写 HTTP、HTTPS、SOCKS 代理，并提供格式、字幕、浏览器 Cookie 失败兜底等高级设置。
 - 媒体处理：支持文件和目录拖拽、中文 MediaInfo 信息、转换、重新封装、
   视频/音频/字幕抽流、ASS/SRT、GIF、序列帧以及码率、帧率、尺寸、裁切、
   旋转、速度、像素格式和音频参数。
@@ -56,6 +56,10 @@ winget install --id yt-dlp.yt-dlp -e
 winget install --id MediaArea.MediaInfo.CLI -e
 winget install --id DenoLand.Deno -e
 ```
+
+Windows Lite 不会内置或启动 WebView2 安装器，而是使用系统已有的 WebView2
+Runtime；Windows 10 22H2 和 Windows 11 通常已经提供该 Runtime。若系统确实缺少
+Runtime，Lite 需要先单独安装它，或者改用内置 WebView2 离线安装器的 Full 版。
 
 macOS 可使用 Homebrew：
 
@@ -102,8 +106,9 @@ npm run tauri:build:full
 ```
 
 Windows 构建脚本会校验随仓库分发的 BBDown，并在 Full 构建时下载、校验其余
-Windows sidecar 及 WebView2 离线安装包，随后生成中英双语 NSIS 安装包；这些
-网络访问发生在构建阶段，不是用户安装和启动阶段。未签名安装包可能触发
+Windows sidecar 及 Full 版的 WebView2 离线安装包，随后生成中英双语 NSIS 安装包；这些
+网络访问发生在构建阶段，不是用户安装和启动阶段。Lite 构建不会下载或打包 WebView2
+安装包。未签名安装包可能触发
 SmartScreen 的“未知发布者”提示。
 
 GitHub Actions 可手动运行 Windows 和 Apple Silicon macOS 的 Full/Lite 构建；

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -39,6 +39,11 @@ MAD Toolbox searches the inherited `PATH`, WindowsApps, WinGet Links, Scoop and
 Chocolatey locations, pipx locations and user Python directories. Use Settings
 to choose whether bundled or system tools are preferred.
 
+The Windows Lite installer does not install WebView2. It uses the system
+WebView2 Runtime, which is normally present on Windows 10 22H2 and Windows 11;
+install the runtime separately if it is missing. Use the Full installer when a
+network-free WebView2 installation is required.
+
 Official or project-designated release pages:
 
 - FFmpeg official build index: https://ffmpeg.org/download.html

--- a/docs/FULL_BUILD.md
+++ b/docs/FULL_BUILD.md
@@ -51,6 +51,8 @@ FFmpeg source revision and BtbN build-recipe snapshot under
 The Windows Full NSIS configuration uses WebView2's `offlineInstaller` mode, so
 the WebView2 runtime is embedded in the installer instead of being fetched from
 the internet during installation. The Windows Lite installer uses
-`src-tauri/tauri.windows.lite.conf.json` and contains BBDown only. Full and Lite
-share the same application code; runtime tool-source settings decide whether
-bundled or system executables are used.
+`src-tauri/tauri.windows.lite.conf.json`, contains BBDown only, and sets
+WebView2's `skip` mode so it does not show a setup dialog or carry the offline
+runtime payload. Lite therefore requires the system WebView2 Runtime. Full and
+Lite share the same application code; runtime tool-source settings decide
+whether bundled or system executables are used.

--- a/docs/WINDOWS.md
+++ b/docs/WINDOWS.md
@@ -1,6 +1,6 @@
 # Windows x64 build
 
-MAD Toolbox 0.5.11 targets Windows 10 22H2 and Windows 11 on Intel/AMD x64
+MAD Toolbox 0.5.12 targets Windows 10 22H2 and Windows 11 on Intel/AMD x64
 processors (`x86_64-pc-windows-msvc`). ARM64 and 32-bit x86 installers are not
 currently produced.
 
@@ -40,8 +40,11 @@ the WebView2 offline installer. After the Full installer has been downloaded,
 installation and application startup do not require an internet connection.
 Lite bundles BBDown and finds the other programs from WinGet/system and other
 known Windows installation locations, so Lite still requires those dependencies
-to be installed separately. Settings allows either installer to prefer a newer
-system version.
+to be installed separately. Lite also skips the WebView2 installation step and
+uses the system WebView2 Runtime, so it does not show a WebView2 setup dialog or
+carry the Full installer's offline runtime payload. Windows 10 22H2 and Windows
+11 normally include the runtime; if it is missing, install it separately or use
+Full. Settings allows either installer to prefer a newer system version.
 
 Prepare and build:
 
@@ -53,9 +56,10 @@ npm run tauri:build:windows:full
 
 The build scripts download only missing artifacts and verify pinned SHA-256
 values. The output is a per-user bilingual NSIS installer. The build machine
-needs network access when a pinned artifact or the WebView2 offline package is
-not already cached; this does not create a network requirement for the shipped
-Full installer.
+needs network access when a pinned artifact or the Full-only WebView2 offline
+package is not already cached; this does not create a network requirement for
+the shipped Full installer. Lite does not download or package the WebView2
+offline installer.
 
 ## CLI state and diagnostics
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mad-toolbox",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mad-toolbox",
-      "version": "0.5.11",
+      "version": "0.5.12",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mad-toolbox",
   "private": true,
-  "version": "0.5.11",
+  "version": "0.5.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2133,7 +2133,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mad-toolbox"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mad-toolbox"
-version = "0.5.11"
+version = "0.5.12"
 description = "A GUI toolbox for BBDown, yt-dlp, FFmpeg and MediaInfo"
 authors = ["MAD Toolbox Contributors"]
 license = "MIT"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
-    process::Command,
+    process::{Child, Command},
     sync::oneshot,
     time::{sleep, timeout, Duration},
 };
@@ -130,6 +130,7 @@ struct DependencyStatus {
 struct RunRequest {
     tool: ToolName,
     args: Vec<String>,
+    fallback_args: Option<Vec<String>>,
     working_dir: Option<String>,
 }
 
@@ -1314,6 +1315,7 @@ fn safe_command(tool: &ToolName, args: &[String]) -> String {
         "--proxy",
         "--username",
         "--password",
+        "--cookies-from-browser",
     ];
     let mut output = vec![tool.executable().to_string()];
     let mut redact_next = false;
@@ -1349,6 +1351,18 @@ fn validate_args(args: &[String]) -> Result<(), String> {
     Ok(())
 }
 
+fn ensure_ffmpeg_location(args: &mut Vec<String>, ffmpeg: &Path) {
+    if !args.iter().any(|arg| arg == "--ffmpeg-location") {
+        args.splice(
+            0..0,
+            [
+                "--ffmpeg-location".into(),
+                ffmpeg.to_string_lossy().into_owned(),
+            ],
+        );
+    }
+}
+
 fn emit_log(app: &AppHandle, job_id: &str, tool: &ToolName, stream: &'static str, line: String) {
     let _ = app.emit(
         "job-log",
@@ -1362,17 +1376,31 @@ fn emit_log(app: &AppHandle, job_id: &str, tool: &ToolName, stream: &'static str
     );
 }
 
+fn yt_dlp_browser_cookie_fallback_requested(line: &str) -> bool {
+    let normalized = line.to_ascii_lowercase().replace('’', "'");
+    [
+        "sign in to confirm",
+        "confirm you're not a bot",
+        "use --cookies-from-browser",
+        "use --cookies",
+    ]
+    .iter()
+    .any(|marker| normalized.contains(marker))
+}
+
 async fn stream_output<R>(
     reader: R,
     app: AppHandle,
     job_id: String,
     tool: ToolName,
     stream: &'static str,
-) where
+) -> bool
+where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut reader = BufReader::new(reader);
     let mut bytes = Vec::new();
+    let mut browser_cookie_fallback_requested = false;
     loop {
         bytes.clear();
         let Ok(length) = reader.read_until(b'\n', &mut bytes).await else {
@@ -1385,6 +1413,9 @@ async fn stream_output<R>(
             bytes.pop();
         }
         let line = String::from_utf8_lossy(&bytes);
+        if matches!(tool, ToolName::YtDlp) && yt_dlp_browser_cookie_fallback_requested(&line) {
+            browser_cookie_fallback_requested = true;
+        }
         // BBDown also prints an ANSI-colored QR code. The GUI presents the
         // generated PNG instead, so omit those unreadable terminal rows.
         if matches!(tool, ToolName::Bbdown)
@@ -1396,6 +1427,94 @@ async fn stream_output<R>(
         // redaction remains available for the diagnostic ZIP export.
         emit_log(&app, &job_id, &tool, stream, strip_ansi_codes(&line));
     }
+    browser_cookie_fallback_requested
+}
+
+fn spawn_child(
+    executable: &Path,
+    args: &[String],
+    working_dir: Option<&Path>,
+    tool: &ToolName,
+) -> Result<Child, String> {
+    let mut command = Command::new(executable);
+    hide_async_command_window(&mut command);
+    command
+        .args(args)
+        .env("PATH", command_path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    if let Some(directory) = working_dir {
+        std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
+        command.current_dir(directory);
+    }
+    command
+        .spawn()
+        .map_err(|error| format!("无法启动 {}：{error}", tool.label()))
+}
+
+async fn wait_for_child(
+    mut child: Child,
+    app: AppHandle,
+    job_id: String,
+    tool: ToolName,
+    cancel_rx: &mut oneshot::Receiver<()>,
+) -> (&'static str, Option<i32>, String, bool, bool) {
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+    let task_app = app.clone();
+    let task_job_id = job_id.clone();
+    let stdout_task = stdout.map(|pipe| {
+        tauri::async_runtime::spawn(stream_output(
+            pipe,
+            task_app.clone(),
+            task_job_id.clone(),
+            tool.clone(),
+            "stdout",
+        ))
+    });
+    let stderr_task = stderr.map(|pipe| {
+        tauri::async_runtime::spawn(stream_output(
+            pipe,
+            task_app,
+            task_job_id,
+            tool.clone(),
+            "stderr",
+        ))
+    });
+
+    let (state_name, exit_code, message, cancelled) = tokio::select! {
+        result = child.wait() => {
+            match result {
+                Ok(status) if status.success() => {
+                    ("completed", status.code(), format!("{} 已完成", tool.label()), false)
+                }
+                Ok(status) => ("failed", status.code(), format!("{} 执行失败", tool.label()), false),
+                Err(error) => ("failed", None, format!("{} 等待进程失败：{error}", tool.label()), false),
+            }
+        }
+        _ = cancel_rx => {
+            let _ = child.kill().await;
+            ("cancelled", None, format!("{} 已取消", tool.label()), true)
+        }
+    };
+
+    let stdout_requested = match stdout_task {
+        Some(task) => task.await.unwrap_or(false),
+        None => false,
+    };
+    let stderr_requested = match stderr_task {
+        Some(task) => task.await.unwrap_or(false),
+        None => false,
+    };
+    (
+        state_name,
+        exit_code,
+        message,
+        cancelled,
+        stdout_requested || stderr_requested,
+    )
 }
 
 async fn spawn_job(
@@ -1405,27 +1524,14 @@ async fn spawn_job(
     executable: PathBuf,
     args: Vec<String>,
     working_dir: Option<PathBuf>,
+    fallback_args: Option<Vec<String>>,
 ) -> Result<RunResult, String> {
     validate_args(&args)?;
-    let job_id = Uuid::new_v4().to_string();
-    let mut command = Command::new(&executable);
-    hide_async_command_window(&mut command);
-    command
-        .args(&args)
-        .env("PATH", command_path())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-    if let Some(directory) = &working_dir {
-        std::fs::create_dir_all(directory).map_err(|error| error.to_string())?;
-        command.current_dir(directory);
+    if let Some(fallback_args) = &fallback_args {
+        validate_args(fallback_args)?;
     }
-    let mut child = command
-        .spawn()
-        .map_err(|error| format!("无法启动 {}：{error}", tool.label()))?;
-    let stdout = child.stdout.take();
-    let stderr = child.stderr.take();
+    let job_id = Uuid::new_v4().to_string();
+    let child = spawn_child(&executable, &args, working_dir.as_deref(), &tool)?;
     let (cancel_tx, mut cancel_rx) = oneshot::channel();
     state
         .cancel_senders
@@ -1453,58 +1559,79 @@ async fn spawn_job(
 
     let task_app = app.clone();
     let task_job_id = job_id.clone();
+    let task_tool = tool.clone();
     tauri::async_runtime::spawn(async move {
-        let stdout_task = stdout.map(|pipe| {
-            tauri::async_runtime::spawn(stream_output(
-                pipe,
+        let (mut state_name, mut exit_code, mut message, cancelled, browser_cookie_error) =
+            wait_for_child(
+                child,
                 task_app.clone(),
                 task_job_id.clone(),
-                tool.clone(),
-                "stdout",
-            ))
-        });
-        let stderr_task = stderr.map(|pipe| {
-            tauri::async_runtime::spawn(stream_output(
-                pipe,
-                task_app.clone(),
-                task_job_id.clone(),
-                tool.clone(),
-                "stderr",
-            ))
-        });
+                task_tool.clone(),
+                &mut cancel_rx,
+            )
+            .await;
 
-        let (state_name, exit_code, message) = tokio::select! {
-            result = child.wait() => {
-                match result {
-                    Ok(status) if status.success() => {
-                        ("completed", status.code(), format!("{} 已完成", tool.label()))
+        if !cancelled && cancel_rx.try_recv().is_ok() {
+            state_name = "cancelled";
+            exit_code = None;
+            message = format!("{} 已取消", task_tool.label());
+        }
+
+        if state_name == "failed" && browser_cookie_error && !cancelled {
+            if let Some(retry_args) = fallback_args.as_ref() {
+                emit_log(
+                    &task_app,
+                    &task_job_id,
+                    &task_tool,
+                    "system",
+                    "yt-dlp 首次请求未使用浏览器 Cookie，检测到需要登录，正在使用浏览器 Cookie 重试。"
+                        .into(),
+                );
+                emit_log(
+                    &task_app,
+                    &task_job_id,
+                    &task_tool,
+                    "system",
+                    format!("$ {}", safe_command(&task_tool, retry_args)),
+                );
+                match spawn_child(&executable, retry_args, working_dir.as_deref(), &task_tool) {
+                    Ok(retry_child) => {
+                        let (retry_state, retry_exit_code, retry_message, _, _) = wait_for_child(
+                            retry_child,
+                            task_app.clone(),
+                            task_job_id.clone(),
+                            task_tool.clone(),
+                            &mut cancel_rx,
+                        )
+                        .await;
+                        state_name = retry_state;
+                        exit_code = retry_exit_code;
+                        message = retry_message;
                     }
-                    Ok(status) => ("failed", status.code(), format!("{} 执行失败", tool.label())),
-                    Err(error) => ("failed", None, format!("{} 等待进程失败：{error}", tool.label())),
+                    Err(error) => {
+                        state_name = "failed";
+                        exit_code = None;
+                        message = format!("yt-dlp 浏览器 Cookie 重试无法启动：{error}");
+                    }
                 }
             }
-            _ = &mut cancel_rx => {
-                let _ = child.kill().await;
-                ("cancelled", None, format!("{} 已取消", tool.label()))
-            }
-        };
-
-        if let Some(task) = stdout_task {
-            let _ = task.await;
-        }
-        if let Some(task) = stderr_task {
-            let _ = task.await;
         }
         if let Ok(mut senders) = task_app.state::<AppState>().cancel_senders.lock() {
             senders.remove(&task_job_id);
         }
         // Keep files generated by the CLI itself, including qrcode.png.
-        emit_log(&task_app, &task_job_id, &tool, "system", message.clone());
+        emit_log(
+            &task_app,
+            &task_job_id,
+            &task_tool,
+            "system",
+            message.clone(),
+        );
         let _ = task_app.emit(
             "job-state",
             JobState {
                 job_id: task_job_id,
-                tool,
+                tool: task_tool,
                 state: state_name,
                 exit_code,
                 message,
@@ -1944,6 +2071,18 @@ async fn run_tool(
     state: State<'_, AppState>,
     mut request: RunRequest,
 ) -> Result<RunResult, String> {
+    if let Some(fallback_args) = request.fallback_args.as_ref() {
+        if !matches!(request.tool, ToolName::YtDlp) {
+            return Err("浏览器 Cookie 兜底只能用于 yt-dlp".into());
+        }
+        if !fallback_args
+            .iter()
+            .any(|arg| arg == "--cookies-from-browser")
+        {
+            return Err("浏览器 Cookie 兜底参数缺少 --cookies-from-browser".into());
+        }
+        validate_args(fallback_args)?;
+    }
     let (resolved_executable, _bundled) = resolve_tool(&app, &request.tool)
         .ok_or_else(|| format!("未找到 {}，请先安装依赖", request.tool.label()))?;
     let executable = resolved_executable;
@@ -1953,13 +2092,10 @@ async fn run_tool(
         && !request.args.iter().any(|arg| arg == "--ffmpeg-location")
     {
         if let Some((ffmpeg, _)) = resolve_tool(&app, &ToolName::Ffmpeg) {
-            request.args.splice(
-                0..0,
-                [
-                    "--ffmpeg-location".into(),
-                    ffmpeg.to_string_lossy().into_owned(),
-                ],
-            );
+            ensure_ffmpeg_location(&mut request.args, &ffmpeg);
+            if let Some(fallback_args) = request.fallback_args.as_mut() {
+                ensure_ffmpeg_location(fallback_args, &ffmpeg);
+            }
         }
     }
 
@@ -1981,6 +2117,7 @@ async fn run_tool(
         executable,
         request.args,
         working_dir,
+        request.fallback_args,
     )
     .await
 }
@@ -2261,6 +2398,7 @@ async fn musicdl_download(
             selected,
         ],
         None,
+        None,
     )
     .await
 }
@@ -2342,6 +2480,7 @@ async fn musicdl_playlist(
             "playlist".into(),
             request_path.to_string_lossy().into_owned(),
         ],
+        None,
         None,
     )
     .await
@@ -2929,6 +3068,7 @@ async fn run_pr_compatible(
                 ffmpeg.clone(),
                 args,
                 None,
+                None,
             )
             .await?,
         );
@@ -2969,6 +3109,7 @@ mod tests {
         is_text_subtitle_file, media_info_summary, musicdl_launcher_python, parse_query_fields,
         poll_bbdown_qr_at, pr_audio_container, pr_container, redact_output_line,
         sanitize_diagnostic_text, streams_from_probe, strip_ansi_codes,
+        yt_dlp_browser_cookie_fallback_requested,
     };
     use serde_json::json;
     use std::{
@@ -3124,6 +3265,22 @@ mod tests {
             strip_ansi_codes("Searching \u{1b}[93m稻香\u{1b}[0m From Migu"),
             "Searching 稻香 From Migu"
         );
+    }
+
+    #[test]
+    fn recognizes_yt_dlp_browser_cookie_fallback_errors() {
+        assert!(yt_dlp_browser_cookie_fallback_requested(
+            "ERROR: Sign in to confirm you're not a bot."
+        ));
+        assert!(yt_dlp_browser_cookie_fallback_requested(
+            "Use --cookies-from-browser or --cookies for the authentication."
+        ));
+        assert!(yt_dlp_browser_cookie_fallback_requested(
+            "Please sign in to confirm you’re not a bot."
+        ));
+        assert!(!yt_dlp_browser_cookie_fallback_requested(
+            "ERROR: Unable to download webpage: network timeout"
+        ));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MAD Toolbox",
-  "version": "0.5.11",
+  "version": "0.5.12",
   "identifier": "org.madproducer.toolbox",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.windows.lite.conf.json
+++ b/src-tauri/tauri.windows.lite.conf.json
@@ -26,8 +26,7 @@
     },
     "windows": {
       "webviewInstallMode": {
-        "type": "offlineInstaller",
-        "silent": true
+        "type": "skip"
       },
       "allowDowngrades": false,
       "nsis": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,17 +35,6 @@ import appIcon from "./assets/app-icon.png";
 import { platformLabel } from "./lib/platform";
 import packageInfo from "../package.json";
 
-const APP_LOGO_STORAGE_KEY = "mad-toolbox.custom-logo";
-
-function loadStoredLogo() {
-  try {
-    const stored = localStorage.getItem(APP_LOGO_STORAGE_KEY);
-    return stored?.startsWith("data:image/") ? stored : appIcon;
-  } catch {
-    return appIcon;
-  }
-}
-
 const navItems: Array<{
   page: NavPage;
   label: string;
@@ -72,7 +61,6 @@ const utilityItems: Array<{
 export default function App() {
   const [page, setPage] = useState<NavPage>("home");
   const [toast, setToast] = useState<string | null>(null);
-  const [logo, setLogo] = useState(loadStoredLogo);
   const backend = useBackend();
   const distributionMode =
     backend.dependencies.some((item) => item.required) &&
@@ -84,19 +72,6 @@ export default function App() {
     const message = error instanceof Error ? error.message : String(error);
     setToast(message);
     window.setTimeout(() => setToast(null), 5000);
-  };
-
-  const updateLogo = (nextLogo: string | null) => {
-    try {
-      if (nextLogo) {
-        localStorage.setItem(APP_LOGO_STORAGE_KEY, nextLogo);
-      } else {
-        localStorage.removeItem(APP_LOGO_STORAGE_KEY);
-      }
-      setLogo(nextLogo || appIcon);
-    } catch {
-      throw new Error("无法保存 Logo，请选择更小的图片后重试");
-    }
   };
 
   const run = async (request: RunRequest) => {
@@ -255,9 +230,6 @@ export default function App() {
         <SettingsPage
           settings={backend.settings}
           distributionMode={distributionMode}
-          logo={logo}
-          logoIsCustom={logo !== appIcon}
-          onLogoChange={updateLogo}
           onSave={async (settings) => {
             const saved = await backend.saveSettings(settings);
             await backend.refreshDependencies();
@@ -275,7 +247,7 @@ export default function App() {
         <div className="window-drag" data-tauri-drag-region />
         <div className="brand">
           <span className="brand-icon">
-            <img src={logo} alt="" />
+            <img src={appIcon} alt="" />
           </span>
           <span>
             <strong>MAD Toolbox</strong>

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -8,7 +8,8 @@ const SECRET_FLAGS = new Set([
   "--proxy",
   "--username",
   "--password",
-  "--video-password"
+  "--video-password",
+  "--cookies-from-browser"
 ]);
 
 export function shellQuote(value: string): string {
@@ -227,14 +228,18 @@ export interface YtDlpOptions {
   verbose: boolean;
 }
 
-export function buildYtDlpArgs(options: YtDlpOptions, denoPath?: string | null): string[] {
+export function buildYtDlpArgs(
+  options: YtDlpOptions,
+  denoPath?: string | null,
+  includeBrowserCookies = true
+): string[] {
   const args: string[] = [];
   if (denoPath) args.push("--js-runtimes", `deno:${denoPath}`);
   if (options.proxy.trim()) args.push("--proxy", options.proxy.trim());
   if (options.outputDirectory.trim()) args.push("-P", options.outputDirectory.trim());
   if (options.outputTemplate.trim()) args.push("-o", options.outputTemplate.trim());
   if (options.format.trim()) args.push("-f", options.format.trim());
-  if (options.cookiesBrowser.trim()) {
+  if (includeBrowserCookies && options.cookiesBrowser.trim()) {
     args.push("--cookies-from-browser", options.cookiesBrowser.trim());
   }
   if (options.playlistItems.trim()) args.push("-I", options.playlistItems.trim());

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,6 +53,7 @@ export interface LogExportRequest {
 export interface RunRequest {
   tool: ToolName;
   args: string[];
+  fallbackArgs?: string[] | null;
   workingDir?: string | null;
 }
 

--- a/src/pages/NetworkPage.tsx
+++ b/src/pages/NetworkPage.tsx
@@ -55,7 +55,8 @@ export function NetworkPage({
   const [advanced, setAdvanced] = useState(false);
   const [network, setNetwork] = useState<"unknown" | "checking" | "online" | "offline">("unknown");
   const checkedOnce = useRef(false);
-  const args = useMemo(() => buildYtDlpArgs(options, denoPath), [options, denoPath]);
+  const args = useMemo(() => buildYtDlpArgs(options, denoPath, false), [options, denoPath]);
+  const fallbackArgs = useMemo(() => buildYtDlpArgs(options, denoPath), [options, denoPath]);
   const preview = commandPreview("yt-dlp", args);
   const templateOptions = useMemo(() => {
     const { url: _url, ...settings } = options;
@@ -155,7 +156,7 @@ export function NetworkPage({
         <div className="form-grid network-auth-grid">
           <Field
             label="浏览器 Cookie"
-            hint="YouTube 出现“需要登录或确认不是机器人”时，选择已经登录的浏览器。应用只传递浏览器名称，不保存 Cookie 内容；Windows 上建议先完全退出浏览器再运行。"
+            hint="先进行无 Cookie 请求；只有 yt-dlp 返回需要登录或确认不是机器人时，才会使用这里选择的浏览器 Cookie 重试。应用只传递浏览器名称，不保存 Cookie 内容；Windows 上建议先完全退出浏览器再运行。"
           >
             <SelectInput
               value={selectedBrowserCookie}
@@ -191,9 +192,20 @@ export function NetworkPage({
             <div>
               <strong>YouTube 可能要求登录</strong>
               <p>
-                如果任务日志出现 “Sign in to confirm you’re not a
-                bot”，请在上方选择已登录的浏览器；这只读取本机浏览器 Cookie，不会把 Cookie
-                内容写入应用设置。
+                如果任务日志出现 “Sign in to confirm you’re not a bot”，请在上方选择已登录的
+                浏览器。选择后会先尝试无 Cookie 请求，只有检测到这类登录验证错误时才会自动
+                读取浏览器 Cookie 重试。
+              </p>
+            </div>
+          </div>
+        )}
+        {options.cookiesBrowser.trim() && (
+          <div className="notice info">
+            <div>
+              <strong>已启用浏览器 Cookie 失败兜底</strong>
+              <p>
+                当前命令预览保持无 Cookie 请求；如果 yt-dlp 报告需要登录或人机验证，任务会在同一
+                个任务中自动使用所选浏览器 Cookie 重试。
               </p>
             </div>
           </div>
@@ -324,7 +336,13 @@ export function NetworkPage({
       </section>
       <CommandBar
         command={preview}
-        onRun={() => void onRun({ tool: "yt-dlp", args })}
+        onRun={() =>
+          void onRun({
+            tool: "yt-dlp",
+            args,
+            fallbackArgs: options.cookiesBrowser.trim() ? fallbackArgs : undefined
+          })
+        }
         disabled={!options.url.trim() || !ytDlpAvailable || youtubeBlocked}
         disabledReason={
           !ytDlpAvailable

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,27 +13,16 @@ import {
 interface SettingsPageProps {
   settings: AppSettings;
   distributionMode: "Lite" | "Full";
-  logo: string;
-  logoIsCustom: boolean;
-  onLogoChange: (logo: string | null) => void;
   onSave: (settings: AppSettings) => Promise<AppSettings>;
 }
 
-export function SettingsPage({
-  settings,
-  distributionMode,
-  logo,
-  logoIsCustom,
-  onLogoChange,
-  onSave
-}: SettingsPageProps) {
+export function SettingsPage({ settings, distributionMode, onSave }: SettingsPageProps) {
   const [directory, setDirectory] = useState(settings.defaultOutputDirectory || "");
   const [dependencyPreference, setDependencyPreference] = useState(settings.dependencyPreference);
   const [state, setState] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [preferenceState, setPreferenceState] = useState<"idle" | "saving" | "saved" | "error">(
     "idle"
   );
-  const [logoError, setLogoError] = useState<string | null>(null);
 
   useEffect(() => {
     setDirectory(settings.defaultOutputDirectory || "");
@@ -66,35 +55,6 @@ export function SettingsPage({
     } catch {
       setPreferenceState("error");
     }
-  };
-
-  const chooseLogo = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    event.target.value = "";
-    if (!file) return;
-    if (!(file.type === "image/png" || file.type === "image/jpeg" || file.type === "image/webp")) {
-      setLogoError("Logo 只支持 PNG、JPEG 或 WebP 图片。");
-      return;
-    }
-    if (file.size > 2 * 1024 * 1024) {
-      setLogoError("Logo 图片不能超过 2 MB。");
-      return;
-    }
-    const reader = new FileReader();
-    reader.onload = () => {
-      if (typeof reader.result !== "string") {
-        setLogoError("Logo 读取失败，请换一张图片。");
-        return;
-      }
-      try {
-        onLogoChange(reader.result);
-        setLogoError(null);
-      } catch (error) {
-        setLogoError(error instanceof Error ? error.message : "Logo 保存失败。");
-      }
-    };
-    reader.onerror = () => setLogoError("Logo 读取失败，请换一张图片。");
-    reader.readAsDataURL(file);
   };
 
   return (
@@ -133,48 +93,6 @@ export function SettingsPage({
         {state === "error" && (
           <span className="setting-error">保存失败，请选择一个存在的目录。</span>
         )}
-      </section>
-      <section className="settings-section">
-        <h2>应用 Logo</h2>
-        <p>
-          可上传第三方设计的 PNG、JPEG 或 WebP 图片。它只更换应用界面中的
-          Logo，安装包和系统任务栏图标仍使用正式图标；选择后会在重启时保留。
-        </p>
-        <div className="logo-settings-row">
-          <span className="logo-settings-preview">
-            <img src={logo} alt="当前应用 Logo" />
-          </span>
-          <div className="logo-settings-actions">
-            <strong>{logoIsCustom ? "正在使用自定义 Logo" : "正在使用默认 Logo"}</strong>
-            <div>
-              <label className="secondary-button logo-upload-button">
-                选择图片
-                <input
-                  type="file"
-                  accept="image/png,image/jpeg,image/webp"
-                  onChange={chooseLogo}
-                  hidden
-                />
-              </label>
-              <button
-                className="secondary-button"
-                type="button"
-                disabled={!logoIsCustom}
-                onClick={() => {
-                  try {
-                    onLogoChange(null);
-                    setLogoError(null);
-                  } catch (error) {
-                    setLogoError(error instanceof Error ? error.message : "Logo 恢复失败。");
-                  }
-                }}
-              >
-                恢复默认
-              </button>
-            </div>
-          </div>
-        </div>
-        {logoError && <span className="setting-error">{logoError}</span>}
       </section>
       <section className="settings-section">
         <div className="settings-heading-row">

--- a/src/styles.css
+++ b/src/styles.css
@@ -952,48 +952,6 @@ button:disabled {
   font-size: 9px;
 }
 
-.logo-settings-row {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  margin-top: 13px;
-}
-
-.logo-settings-preview {
-  display: grid;
-  width: 58px;
-  height: 58px;
-  flex: 0 0 auto;
-  place-items: center;
-  overflow: hidden;
-  border: 1px solid #e2e1e7;
-  border-radius: 13px;
-  background: #f7f6ff;
-}
-
-.logo-settings-preview img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.logo-settings-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 9px;
-}
-
-.logo-settings-actions > div {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-}
-
-.logo-upload-button {
-  cursor: pointer;
-}
-
 .parameter-section {
   margin-top: 18px;
   padding-top: 16px;


### PR DESCRIPTION
## 变更内容

- Fixes #10：网络视频下载先执行无 Cookie 的 yt-dlp 请求；只有检测到需要登录或人机验证提示时，才在同一任务中使用用户选择的浏览器 Cookie 自动重试。普通网络错误不会触发 Cookie 读取，任务日志会隐藏浏览器参数值。
- Fixes #17：移除设置页的自定义 Logo 上传、持久化和恢复功能，界面统一使用正式应用图标。
- Fixes #18：Windows Lite 改用 WebView2 `skip` 模式，不再内置或启动 WebView2 setup；Full 继续使用静默的 WebView2 离线安装器。相关文档已说明 Lite 需要系统已有 WebView2 Runtime。

## 验证

- `npm run format:check`
- `npm run check`
- `npm run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml`：15/15 通过
- Lite/Full Tauri 配置合并构建验证通过

已有的 Windows 二进制文件未加入本次提交。