### PR TITLE
发布 MAD Toolbox v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to MAD Toolbox are documented here.
 
+## 0.6.0 - 正式版 (2026-08-12)
+
+- 修复 Windows 子进程中文输出乱码：自动识别 UTF-8，必要时按 GBK/CP936 解码；任务中心、依赖信息、媒体错误信息和导出日志统一修复，Windows 导出日志同时写入 UTF-8 BOM。
+- 修复哔哩哔哩、网络视频、音乐下载和媒体处理的输出目录逻辑：显式填写的目录优先，未填写时使用设置中的默认目录，再回退到系统下载目录。
+- 修复 yt-dlp 浏览器 Cookie 兜底重试与首次请求使用不同输出目录的问题。
+- 修复哔哩哔哩下载没有使用设置页默认目录的问题，并保留 BBDown 的原生工作目录和登录状态行为。
+- 移除设置中的自定义 Logo 功能，界面统一使用正式应用图标。
+- 修复 Windows Lite 的 WebView2 setup 弹窗；Lite 使用系统已有 Runtime，Full 保留离线 WebView2 安装能力。
+- 完善 Windows Full/Lite 与 macOS Apple Silicon Full/Lite 的构建和离线依赖打包验证。
+
 ## 0.5.12 - Pre-release (2026-08-12)
 
 - 移除设置中的自定义 Logo 功能，应用界面统一使用正式图标，避免只修改局部界面而造成误解。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mad-toolbox",
-  "version": "0.5.12",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mad-toolbox",
-      "version": "0.5.12",
+      "version": "0.6.0",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/plugin-dialog": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mad-toolbox",
   "private": true,
-  "version": "0.5.12",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2133,7 +2133,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mad-toolbox"
-version = "0.5.12"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mad-toolbox"
-version = "0.5.12"
+version = "0.6.0"
 description = "A GUI toolbox for BBDown, yt-dlp, FFmpeg and MediaInfo"
 authors = ["MAD Toolbox Contributors"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "MAD Toolbox",
-  "version": "0.5.12",
+  "version": "0.6.0",
   "identifier": "org.madproducer.toolbox",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## 变更内容

- 将项目版本统一更新为 0.6.0。
- 增加正式版变更记录，涵盖 Windows 中文输出乱码、输出目录、Cookie 兜底、设置页 Logo、WebView2 Lite 弹窗和离线依赖打包等修复。
- 本 PR 仅包含版本与变更记录，不包含本地未跟踪的 Windows 二进制文件。

## 验证

- npm run format:check
- npm run check
- npm run build
- cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
- cargo test --manifest-path src-tauri/Cargo.toml --locked：18/18 通过